### PR TITLE
Redo logging config in pbsmrtpipe

### DIFF
--- a/pbsmrtpipe/__init__.py
+++ b/pbsmrtpipe/__init__.py
@@ -1,4 +1,4 @@
-VERSION = (0, 19, 10)
+VERSION = (0, 20, 0)
 
 
 def get_version():

--- a/pbsmrtpipe/cli.py
+++ b/pbsmrtpipe/cli.py
@@ -333,7 +333,7 @@ def _args_run_pipeline(args):
     return D.run_pipeline(pipelines_d, registered_files_d, registered_tasks_d, chunk_operators,
                           args.pipeline_template_xml,
                           ep_d, args.output_dir, args.preset_xml, args.preset_rc_xml, args.service_uri,
-                          force_distribute=force_distribute, force_chunk_mode=force_chunk)
+                          force_distribute=force_distribute, force_chunk_mode=force_chunk, debug_mode=args.debug)
 
 
 def _validate_entry_id(e):
@@ -470,7 +470,7 @@ def _args_task_runner(args):
                              ee_pd, args.task_id, args.output_dir,
                              args.preset_xml, args.preset_rc_xml, args.service_uri,
                              force_distribute=force_distribute,
-                             force_chunk_mode=force_chunk)
+                             force_chunk_mode=force_chunk, debug_mode=args.debug)
 
 
 def _args_run_show_workflow_level_options(args):
@@ -574,8 +574,9 @@ def _pbsmrtipe_setup_log(alog, **kwargs):
 
     str_formatter = '[%(levelname)s] %(asctime)-15s %(message)s'
 
+    level = kwargs.get('level', logging.INFO)
     setup_log(alog,
-              level=logging.INFO,
+              level=level,
               file_name=None,
               log_filter=StdOutStatusLogFilter(),
               str_formatter=str_formatter)

--- a/pbsmrtpipe/driver_utils.py
+++ b/pbsmrtpipe/driver_utils.py
@@ -15,7 +15,7 @@ import pbsmrtpipe.graph.bgraph_utils as BU
 import pbsmrtpipe.pb_io as IO
 from pbsmrtpipe.graph.models import VALID_ALL_TASK_NODE_CLASSES
 from pbsmrtpipe.models import TaskStates, JobResources, RunnableTask
-from pbsmrtpipe.utils import setup_log
+from pbsmrtpipe.utils import setup_log, setup_internal_logs
 
 log = logging.getLogger(__name__)
 slog = logging.getLogger('status.' + __name__)
@@ -300,7 +300,7 @@ def _log_pbsmrptipe_header():
     return s
 
 
-def job_resource_create_and_setup_logs(alog, job_root_dir, bg, task_opts, workflow_level_opts, ep_d):
+def job_resource_create_and_setup_logs(job_root_dir, bg, task_opts, workflow_level_opts, ep_d):
     """
     Create job resource dirs and setup log handlers
 
@@ -313,8 +313,15 @@ def job_resource_create_and_setup_logs(alog, job_root_dir, bg, task_opts, workfl
 
     job_resources = to_job_resources_and_create_dirs(job_root_dir)
 
-    setup_log(alog, level=logging.INFO, file_name=os.path.join(job_resources.logs, 'pbsmrtpipe.log'))
-    setup_log(alog, level=logging.DEBUG, file_name=os.path.join(job_resources.logs, 'master.log'))
+    pb_log_path = os.path.join(job_resources.logs, 'pbsmrtpipe.log')
+    master_log_path = os.path.join(job_resources.logs, "master.log")
+    master_log_level = logging.INFO
+    stdout_level = logging.INFO
+    if workflow_level_opts.debug_mode:
+        master_log_level = logging.DEBUG
+        stdout_level = logging.DEBUG
+
+    setup_internal_logs(master_log_path, master_log_level, pb_log_path, stdout_level)
 
     log.info("Starting pbsmrtpipe v{v}".format(v=pbsmrtpipe.get_version()))
     log.info("\n" + _log_pbsmrptipe_header())

--- a/pbsmrtpipe/graph/bgraph.py
+++ b/pbsmrtpipe/graph/bgraph.py
@@ -845,7 +845,7 @@ def resolve_successor_binding_file_path(g):
         path = attrs.get(ConstantsNodes.FILE_ATTR_PATH, None)
 
         if is_resolved and path is None:
-            log.warn("Incompatible attrs. Resolved files, must have path defined. File {f}".format(f=fnode))
+            log.debug("Incompatible attrs. Resolved files, must have path defined. File {f}".format(f=fnode))
 
         if is_resolved and path is not None:
             snodes = g.successors(fnode)
@@ -1446,7 +1446,7 @@ def resolve_io_files(id_to_count, output_dir, input_files, output_file_type_list
         override_names = [None for _ in output_file_type_list] if output_files_names is None else output_files_names
     else:
         if len(output_files_names) != len(output_file_type_list):
-            log.warning("IGNORING override file names. Incompatible file type list ({i}) and override names ({f})".format(i=len(output_file_type_list), f=len(output_files_names)))
+            log.debug("IGNORING override file names. Incompatible file type list ({i}) and override names ({f})".format(i=len(output_file_type_list), f=len(output_files_names)))
             override_names = [None for _ in output_file_type_list]
         else:
             override_names = output_files_names

--- a/pbsmrtpipe/opts_graph.py
+++ b/pbsmrtpipe/opts_graph.py
@@ -453,10 +453,10 @@ def meta_task_to_task(meta_task,
     log.debug(pprint.pformat(nodes))
 
     for node in nodes:
-        log.debug("Trying to resolve '{r}'".format(r=node))
+        # log.debug("Trying to resolve '{r}'".format(r=node))
         if node in resolved_values:
             # nothing to do here
-            log.debug("Value {n} has been resolved. '{v}'".format(n=node, v=resolved_values[node]))
+            # log.debug("Value {n} has been resolved. '{v}'".format(n=node, v=resolved_values[node]))
             pass
         else:
             # Are we using default funcs to resolve values
@@ -483,8 +483,8 @@ def meta_task_to_task(meta_task,
                                 raise ValueError("$ value '{x}' not resolved.".format(x=x))
                         else:
                             injectable.append(x)
-                    log.debug(f.__name__)
-                    log.debug(injectable)
+                    # log.debug(f.__name__)
+                    # log.debug(injectable)
 
                     # this should do an argsinpsect. Putting a TypeError try/catch
                     # could be misleading
@@ -503,7 +503,7 @@ def meta_task_to_task(meta_task,
                     resolved_values[dollar_key] = value
             else:
                 msg = "potentially unsupported value '{n}'".format(n=node)
-                log.warn(msg)
+                #log.warn(msg)
                 #raise ValueError(msg)
 
     # Sanity Check to make sure required values are resolved

--- a/pbsmrtpipe/pb_io.py
+++ b/pbsmrtpipe/pb_io.py
@@ -138,7 +138,10 @@ def _parse_task_from_advanced_binding_str(b):
 
 
 def binding_str_to_task_id_and_instance_id(s):
+    """Returns a task type id, instance id, in-out positional index
 
+    :raises: MalformedBindingStrError
+    """
     try:
         task_id, instance_id, in_out_index = _parse_task_from_advanced_binding_str(s)
     except MalformedBindingStrError:
@@ -246,6 +249,13 @@ def _get_exit_on_failure():
                                "Immediately exit if a task fails (Instead of trying to run as many tasks as possible before exiting.", False)
 
 
+@register_workflow_option
+def _get_exit_on_failure():
+    return OP.to_option_schema(_to_wopt_id("debug_mode"), "boolean", "Enable Debug Mode",
+                               "Debug will emit debug messages to Stdout and set the level in the master log to DEBUG.", False)
+
+
+
 def validate_or_modify_workflow_level_options(wopts):
     """
     This will adjust or modify intra-option dependencies.
@@ -289,11 +299,13 @@ class WorkflowLevelOptions(collections.Sized):
                   "cluster_manager_path": _to_wopt_id("cluster_manager"),
                   "tmp_dir": _to_wopt_id("tmp_dir"),
                   "progress_status_url": _to_wopt_id("progress_status_url"),
-                  "exit_on_failure": _to_wopt_id("exit_on_failure")}
+                  "exit_on_failure": _to_wopt_id("exit_on_failure"),
+                  "debug_mode": _to_wopt_id("debug_mode")
+                  }
 
     def __init__(self, chunk_mode, max_nchunks, max_nproc, total_max_nproc, max_nworkers,
                  distributed_mode, cluster_manager_path, tmp_dir,
-                 progress_status_url, exit_on_failure):
+                 progress_status_url, exit_on_failure, debug_mode):
         """ Container for the known workflow options"""
         self.chunk_mode = chunk_mode
         self.max_nchunks = max_nchunks
@@ -307,6 +319,7 @@ class WorkflowLevelOptions(collections.Sized):
         self.tmp_dir = tmp_dir
         self.progress_status_url = progress_status_url
         self.exit_on_failure = exit_on_failure
+        self.debug_mode = debug_mode
 
     @staticmethod
     def from_defaults():

--- a/pbsmrtpipe/tests/test_driver.py
+++ b/pbsmrtpipe/tests/test_driver.py
@@ -51,7 +51,7 @@ def _get_entry_points():
 
 
 def _to_wopts(tmp_dir):
-    return WorkflowLevelOptions(True, 24, 6, 18, 24, False, None, tmp_dir, None, True)
+    return WorkflowLevelOptions(True, 24, 6, 18, 24, False, None, tmp_dir, None, True, True)
 
 
 def _test_run_driver(chunk_operators, register_tasks_d, rfiles_d, ep_d, bg, job_output_dir, tmp_dir, task_opts, cluster_renderer):
@@ -62,7 +62,7 @@ def _test_run_driver(chunk_operators, register_tasks_d, rfiles_d, ep_d, bg, job_
     log.debug(("output dir", job_output_dir))
     log.debug(("tmp dir", tmp_dir))
 
-    workflow_level_options = WorkflowLevelOptions(True, 24, 6, 18, 24, False, None, tmp_dir, None, True)
+    workflow_level_options = WorkflowLevelOptions(True, 24, 6, 18, 24, False, None, tmp_dir, None, True, True)
 
     log.debug(workflow_level_options)
 


### PR DESCRIPTION
Added new pbsmrtpipe.options.debug_mode that can specified in the preset.xml

There's still some need fixes, but this is good enough for now. The fundamentally model should be pushed down to pbcommand.

Any tools called via python -m (used in the RTC driver) are not going to have the log setup correctly because of disable_existing_loggers is not set correctly.