### PR TITLE
Basic falcon example works

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -69,3 +69,6 @@ extras/pipeline-templates-avro/*
 testkit-data/*/job_output
 testkit-data/*/run.sh
 sync_over_sa3_build.sh
+
+.eggs/
+*.swp

--- a/pbsmrtpipe/chunk_operators/operator_chunk_task_falcon0_daligner.xml
+++ b/pbsmrtpipe/chunk_operators/operator_chunk_task_falcon0_daligner.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<chunk-operator id="pbsmrtpipe.operators.chunk_task_falcon0_run_daligner_jobs">
+
+    <task-id>falcon_ns.tasks.task_falcon0_run_daligner_jobs</task-id>
+
+    <scatter>
+        <scatter-task-id>pbsmrtpipe.tasks.scatter_run_daligner_jobs</scatter-task-id>
+        <chunks>
+            <chunk out="$chunk.bash_id" in="falcon_ns.tasks.task_falcon0_run_daligner_jobs:0"/>
+        </chunks>
+    </scatter>
+    <!-- Define the Gather Mechanism -->
+    <gather>
+        <chunks>
+            <chunk>
+                <!-- This is actually a txt -->
+                <gather-task-id>pbsmrtpipe.tasks.gather_run_daligner_jobs</gather-task-id>
+                <chunk-key>$chunk.fofn_id</chunk-key>
+                <task-output>falcon_ns.tasks.task_falcon0_run_daligner_jobs:0</task-output>
+            </chunk>
+        </chunks>
+    </gather>
+</chunk-operator>

--- a/pbsmrtpipe/chunk_operators/operator_chunk_task_falcon1_daligner.xml
+++ b/pbsmrtpipe/chunk_operators/operator_chunk_task_falcon1_daligner.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<chunk-operator id="pbsmrtpipe.operators.chunk_task_falcon1_run_daligner_jobs">
+
+    <task-id>falcon_ns.tasks.task_falcon1_run_daligner_jobs</task-id>
+
+    <scatter>
+        <scatter-task-id>pbsmrtpipe.tasks.scatter_run_daligner_jobs</scatter-task-id>
+        <chunks>
+            <chunk out="$chunk.bash_id" in="falcon_ns.tasks.task_falcon1_run_daligner_jobs:0"/>
+        </chunks>
+    </scatter>
+    <!-- Define the Gather Mechanism -->
+    <gather>
+        <chunks>
+            <chunk>
+                <!-- This is actually a txt -->
+                <gather-task-id>pbsmrtpipe.tasks.gather_run_daligner_jobs</gather-task-id>
+                <chunk-key>$chunk.fofn_id</chunk-key>
+                <task-output>falcon_ns.tasks.task_falcon1_run_daligner_jobs:0</task-output>
+            </chunk>
+        </chunks>
+    </gather>
+</chunk-operator>

--- a/pbsmrtpipe/loader.py
+++ b/pbsmrtpipe/loader.py
@@ -147,6 +147,7 @@ def _load_pipelines_from_python_module_name(name):
     if _REGISTERED_PIPELINES is None:
         import pbsmrtpipe.pb_pipelines.pb_pipelines_dev
         import pbsmrtpipe.pb_pipelines.pb_pipelines_sa3
+        import pbsmrtpipe.pb_pipelines.pb_pipelines_falcon
         from pbsmrtpipe.models import REGISTERED_PIPELINES
         _REGISTERED_PIPELINES = REGISTERED_PIPELINES
 

--- a/pbsmrtpipe/pb_pipelines/pb_pipelines_falcon.py
+++ b/pbsmrtpipe/pb_pipelines/pb_pipelines_falcon.py
@@ -1,0 +1,54 @@
+import logging
+
+from pbsmrtpipe.core import register_pipeline
+from pbsmrtpipe.constants import to_pipeline_ns
+
+from .pb_pipelines_sa3 import Constants
+
+log = logging.getLogger(__name__)
+
+
+def dev_register(relative_id, display_name, tags=()):
+    pipeline_id = to_pipeline_ns(relative_id)
+    ptags = list(set(tags + ('dev', )))
+    return register_pipeline(pipeline_id, display_name, "0.1.0", tags=ptags)
+
+@dev_register("pipe_falcon", "Falcon Pipeline", tags=("local", "chunking"))
+def get_task_falcon_local_pipeline():
+    """Simple example pipeline"""
+    b0 = [
+          ('$entry:e_01', 'falcon_ns.tasks.task_falcon_config:0'),
+          ('falcon_ns.tasks.task_falcon_config:0', 'falcon_ns.tasks.task_falcon_make_fofn_abs:0'),
+    ]
+    br0 = [
+          ('falcon_ns.tasks.task_falcon_config:0',        'falcon_ns.tasks.task_falcon0_build_rdb:0'),
+          ('falcon_ns.tasks.task_falcon_make_fofn_abs:0', 'falcon_ns.tasks.task_falcon0_build_rdb:1'),
+         ]
+
+    br1 = [
+          ('falcon_ns.tasks.task_falcon_config:0',     'falcon_ns.tasks.task_falcon0_run_daligner_jobs:0'),
+          ('falcon_ns.tasks.task_falcon0_build_rdb:0', 'falcon_ns.tasks.task_falcon0_run_daligner_jobs:1'),
+         ]
+    br2 = [
+          ('falcon_ns.tasks.task_falcon_config:0',             'falcon_ns.tasks.task_falcon0_run_merge_consensus_jobs:0'),
+          ('falcon_ns.tasks.task_falcon0_build_rdb:0',         'falcon_ns.tasks.task_falcon0_run_merge_consensus_jobs:1'),
+          ('falcon_ns.tasks.task_falcon0_run_daligner_jobs:0', 'falcon_ns.tasks.task_falcon0_run_merge_consensus_jobs:2'),
+         ]
+    bp0 = [
+          ('falcon_ns.tasks.task_falcon_config:0',                    'falcon_ns.tasks.task_falcon1_build_pdb:0'),
+          ('falcon_ns.tasks.task_falcon0_run_merge_consensus_jobs:0', 'falcon_ns.tasks.task_falcon1_build_pdb:1'),
+         ]
+    bp1 = [
+          ('falcon_ns.tasks.task_falcon_config:0',     'falcon_ns.tasks.task_falcon1_run_daligner_jobs:0'),
+          ('falcon_ns.tasks.task_falcon1_build_pdb:0', 'falcon_ns.tasks.task_falcon1_run_daligner_jobs:1'),
+         ]
+    bp2 = [
+          ('falcon_ns.tasks.task_falcon_config:0',             'falcon_ns.tasks.task_falcon1_run_merge_consensus_jobs:0'),
+          ('falcon_ns.tasks.task_falcon1_build_pdb:0',         'falcon_ns.tasks.task_falcon1_run_merge_consensus_jobs:1'),
+          ('falcon_ns.tasks.task_falcon1_run_daligner_jobs:0', 'falcon_ns.tasks.task_falcon1_run_merge_consensus_jobs:2'),
+         ]
+    bf = [
+            ('falcon_ns.tasks.task_falcon_config:0',                    'falcon_ns.tasks.task_falcon2_run_asm:0'),
+            ('falcon_ns.tasks.task_falcon1_run_merge_consensus_jobs:0', 'falcon_ns.tasks.task_falcon2_run_asm:1'),
+         ]
+    return b0 + br0 + br1 + br2 + bp0 + bp1 + bp2 + bf

--- a/pbsmrtpipe/pb_tasks/tasks_falcon.py
+++ b/pbsmrtpipe/pb_tasks/tasks_falcon.py
@@ -1,0 +1,80 @@
+###################
+# FALCON TASKS
+from pbcommand.cli import registry_builder, registry_runner
+from pbcommand.models import (FileTypes, OutputFileType)
+import logging
+import sys
+
+log = logging.getLogger(__name__)
+
+TOOL_NAMESPACE = 'falcon_ns'
+DRIVER_BASE = "python -m pbsmrtpipe.pb_tasks.tasks_falcon "
+
+#from . import pbcommand_quick as pbquick
+#registry = pbquick.registry_builder(TOOL_NAMESPACE, DRIVER_BASE)
+registry = registry_builder(TOOL_NAMESPACE, DRIVER_BASE)
+
+# FOFN = FileType(to_file_ns("generic_fofn"), "generic", "fofn", 'text/plain')
+FC_FOFN = FileTypes.FOFN
+FC_JSON = FileTypes.JSON
+FC_CONFIG = FileTypes.TXT
+FC_BASH = FileTypes.TXT
+FC_DUMMY = FileTypes.TXT
+
+def FT(file_type, basename):
+    return OutputFileType(file_type.file_type_id,
+                          "Label " + file_type.file_type_id,
+                          repr(file_type),
+                          "description for {f}".format(f=file_type),
+                          basename)
+RDJ = FT(FC_BASH, 'run_daligner_jobs.sh')
+
+@registry('task_falcon_config', '0.0.0', [FC_CONFIG], [FC_JSON], is_distributed=False)
+def run_rtc(rtc):
+    from pbfalcon import tasks as pbfalcon
+    return pbfalcon.run_falcon_config(rtc.task.input_files, rtc.task.output_files)
+
+@registry('task_falcon_make_fofn_abs', '0.0.0', [FC_FOFN], [FC_FOFN], is_distributed=False)
+def run_rtc(rtc):
+    from pbfalcon import tasks as pbfalcon
+    return pbfalcon.run_falcon_make_fofn_abs(rtc.task.input_files, rtc.task.output_files)
+
+@registry('task_falcon0_build_rdb', '0.0.0', [FC_JSON, FC_FOFN], [RDJ, FT(FC_DUMMY, 'job.done')], is_distributed=False)
+def run_rtc(rtc):
+    from pbfalcon import tasks as pbfalcon
+    return pbfalcon.run_falcon_build_rdb(rtc.task.input_files, rtc.task.output_files)
+
+@registry('task_falcon0_run_daligner_jobs', '0.0.0', [FC_JSON, RDJ], [FC_FOFN], is_distributed=False, nproc=4)
+def run_rtc(rtc):
+    from pbfalcon import tasks as pbfalcon
+    return pbfalcon.run_daligner_jobs(rtc.task.input_files, rtc.task.output_files, db_prefix='raw_reads')
+
+@registry('task_falcon0_run_merge_consensus_jobs', '0.0.0', [FC_JSON, RDJ, FC_FOFN], [FC_FOFN], is_distributed=False, nproc=4)
+def run_rtc(rtc):
+    from pbfalcon import tasks as pbfalcon
+    return pbfalcon.run_merge_consensus_jobs(rtc.task.input_files, rtc.task.output_files, db_prefix='raw_reads')
+
+# Run similar steps for preads.
+@registry('task_falcon1_build_pdb', '0.0.0', [FC_JSON, FC_FOFN], [RDJ], is_distributed=False)
+def run_rtc(rtc):
+    from pbfalcon import tasks as pbfalcon
+    return pbfalcon.run_falcon_build_pdb(rtc.task.input_files, rtc.task.output_files)
+
+@registry('task_falcon1_run_daligner_jobs', '0.0.0', [FC_JSON, RDJ], [FC_FOFN], is_distributed=False, nproc=4)
+def run_rtc(rtc):
+    from pbfalcon import tasks as pbfalcon
+    return pbfalcon.run_daligner_jobs(rtc.task.input_files, rtc.task.output_files, db_prefix='preads')
+
+@registry('task_falcon1_run_merge_consensus_jobs', '0.0.0', [FC_JSON, RDJ, FC_FOFN], [FC_FOFN], is_distributed=False, nproc=4)
+def run_rtc(rtc):
+    from pbfalcon import tasks as pbfalcon
+    return pbfalcon.run_merge_consensus_jobs(rtc.task.input_files, rtc.task.output_files, db_prefix='preads')
+
+@registry('task_falcon2_run_asm', '0.0.0', [FC_JSON, FC_FOFN], [FileTypes.FASTA], is_distributed=False, nproc=4)
+def run_rtc(rtc):
+    from pbfalcon import tasks as pbfalcon
+    return pbfalcon.run_falcon_asm(rtc.task.input_files, rtc.task.output_files)
+
+
+if __name__ == '__main__':
+    sys.exit(registry_runner(registry, sys.argv[1:]))

--- a/pbsmrtpipe/registered_tool_contracts/falcon_ns.tasks.task_falcon0_build_rdb_tool_contract.json
+++ b/pbsmrtpipe/registered_tool_contracts/falcon_ns.tasks.task_falcon0_build_rdb_tool_contract.json
@@ -1,0 +1,50 @@
+{
+    "driver": {
+        "env": {}, 
+        "exe": "python -m pbsmrtpipe.pb_tasks.tasks_falcon  run-rtc  ", 
+        "serialization": "json"
+    }, 
+    "tool_contract": {
+        "_comment": "Created by v0.2.13", 
+        "description": "Quick tool task_falcon0_build_rdb falcon_ns.tasks.task_falcon0_build_rdb", 
+        "input_types": [
+            {
+                "description": "description for PacBio.FileTypes.json_0", 
+                "file_type_id": "PacBio.FileTypes.json", 
+                "id": "Label PacBio.FileTypes.json_0", 
+                "title": "<FileType id=PacBio.FileTypes.json name=file.json >"
+            }, 
+            {
+                "description": "description for PacBio.FileTypes.generic_fofn_1", 
+                "file_type_id": "PacBio.FileTypes.generic_fofn", 
+                "id": "Label PacBio.FileTypes.generic_fofn_1", 
+                "title": "<FileType id=PacBio.FileTypes.generic_fofn name=generic.fofn >"
+            }
+        ], 
+        "is_distributed": false, 
+        "name": "Tool task_falcon0_build_rdb", 
+        "nproc": 1, 
+        "output_types": [
+            {
+                "default_name": "run_daligner_jobs.sh", 
+                "description": "description for <FileType id=PacBio.FileTypes.txt name=file.txt >", 
+                "file_type_id": "PacBio.FileTypes.txt", 
+                "id": "Label PacBio.FileTypes.txt", 
+                "title": "<FileType id=PacBio.FileTypes.txt name=file.txt >"
+            }, 
+            {
+                "default_name": "job.done", 
+                "description": "description for <FileType id=PacBio.FileTypes.txt name=file.txt >", 
+                "file_type_id": "PacBio.FileTypes.txt", 
+                "id": "Label PacBio.FileTypes.txt", 
+                "title": "<FileType id=PacBio.FileTypes.txt name=file.txt >"
+            }
+        ], 
+        "resource_types": [], 
+        "schema_options": [], 
+        "task_type": "pbsmrtpipe.task_types.standard", 
+        "tool_contract_id": "falcon_ns.tasks.task_falcon0_build_rdb"
+    }, 
+    "tool_contract_id": "falcon_ns.tasks.task_falcon0_build_rdb", 
+    "version": "0.0.0"
+}

--- a/pbsmrtpipe/registered_tool_contracts/falcon_ns.tasks.task_falcon0_run_daligner_jobs_tool_contract.json
+++ b/pbsmrtpipe/registered_tool_contracts/falcon_ns.tasks.task_falcon0_run_daligner_jobs_tool_contract.json
@@ -1,0 +1,43 @@
+{
+    "driver": {
+        "env": {}, 
+        "exe": "python -m pbsmrtpipe.pb_tasks.tasks_falcon  run-rtc  ", 
+        "serialization": "json"
+    }, 
+    "tool_contract": {
+        "_comment": "Created by v0.2.13", 
+        "description": "Quick tool task_falcon0_run_daligner_jobs falcon_ns.tasks.task_falcon0_run_daligner_jobs", 
+        "input_types": [
+            {
+                "description": "description for PacBio.FileTypes.json_0", 
+                "file_type_id": "PacBio.FileTypes.json", 
+                "id": "Label PacBio.FileTypes.json_0", 
+                "title": "<FileType id=PacBio.FileTypes.json name=file.json >"
+            }, 
+            {
+                "description": "description for PacBio.FileTypes.txt_1", 
+                "file_type_id": "PacBio.FileTypes.txt", 
+                "id": "Label PacBio.FileTypes.txt_1", 
+                "title": "<OutputFileType PacBio.FileTypes.txt Label PacBio.FileTypes.txt >"
+            }
+        ], 
+        "is_distributed": false, 
+        "name": "Tool task_falcon0_run_daligner_jobs", 
+        "nproc": 4, 
+        "output_types": [
+            {
+                "default_name": "generic.fofn", 
+                "description": "description for <FileType id=PacBio.FileTypes.generic_fofn name=generic.fofn >", 
+                "file_type_id": "PacBio.FileTypes.generic_fofn", 
+                "id": "Label PacBio.FileTypes.generic_fofn_0", 
+                "title": "<FileType id=PacBio.FileTypes.generic_fofn name=generic.fofn >"
+            }
+        ], 
+        "resource_types": [], 
+        "schema_options": [], 
+        "task_type": "pbsmrtpipe.task_types.standard", 
+        "tool_contract_id": "falcon_ns.tasks.task_falcon0_run_daligner_jobs"
+    }, 
+    "tool_contract_id": "falcon_ns.tasks.task_falcon0_run_daligner_jobs", 
+    "version": "0.0.0"
+}

--- a/pbsmrtpipe/registered_tool_contracts/falcon_ns.tasks.task_falcon0_run_merge_consensus_jobs_tool_contract.json
+++ b/pbsmrtpipe/registered_tool_contracts/falcon_ns.tasks.task_falcon0_run_merge_consensus_jobs_tool_contract.json
@@ -1,0 +1,49 @@
+{
+    "driver": {
+        "env": {}, 
+        "exe": "python -m pbsmrtpipe.pb_tasks.tasks_falcon  run-rtc  ", 
+        "serialization": "json"
+    }, 
+    "tool_contract": {
+        "_comment": "Created by v0.2.13", 
+        "description": "Quick tool task_falcon0_run_merge_consensus_jobs falcon_ns.tasks.task_falcon0_run_merge_consensus_jobs", 
+        "input_types": [
+            {
+                "description": "description for PacBio.FileTypes.json_0", 
+                "file_type_id": "PacBio.FileTypes.json", 
+                "id": "Label PacBio.FileTypes.json_0", 
+                "title": "<FileType id=PacBio.FileTypes.json name=file.json >"
+            }, 
+            {
+                "description": "description for PacBio.FileTypes.txt_1", 
+                "file_type_id": "PacBio.FileTypes.txt", 
+                "id": "Label PacBio.FileTypes.txt_1", 
+                "title": "<OutputFileType PacBio.FileTypes.txt Label PacBio.FileTypes.txt >"
+            }, 
+            {
+                "description": "description for PacBio.FileTypes.generic_fofn_2", 
+                "file_type_id": "PacBio.FileTypes.generic_fofn", 
+                "id": "Label PacBio.FileTypes.generic_fofn_2", 
+                "title": "<FileType id=PacBio.FileTypes.generic_fofn name=generic.fofn >"
+            }
+        ], 
+        "is_distributed": false, 
+        "name": "Tool task_falcon0_run_merge_consensus_jobs", 
+        "nproc": 4, 
+        "output_types": [
+            {
+                "default_name": "generic.fofn", 
+                "description": "description for <FileType id=PacBio.FileTypes.generic_fofn name=generic.fofn >", 
+                "file_type_id": "PacBio.FileTypes.generic_fofn", 
+                "id": "Label PacBio.FileTypes.generic_fofn_0", 
+                "title": "<FileType id=PacBio.FileTypes.generic_fofn name=generic.fofn >"
+            }
+        ], 
+        "resource_types": [], 
+        "schema_options": [], 
+        "task_type": "pbsmrtpipe.task_types.standard", 
+        "tool_contract_id": "falcon_ns.tasks.task_falcon0_run_merge_consensus_jobs"
+    }, 
+    "tool_contract_id": "falcon_ns.tasks.task_falcon0_run_merge_consensus_jobs", 
+    "version": "0.0.0"
+}

--- a/pbsmrtpipe/registered_tool_contracts/falcon_ns.tasks.task_falcon1_build_pdb_tool_contract.json
+++ b/pbsmrtpipe/registered_tool_contracts/falcon_ns.tasks.task_falcon1_build_pdb_tool_contract.json
@@ -1,0 +1,43 @@
+{
+    "driver": {
+        "env": {}, 
+        "exe": "python -m pbsmrtpipe.pb_tasks.tasks_falcon  run-rtc  ", 
+        "serialization": "json"
+    }, 
+    "tool_contract": {
+        "_comment": "Created by v0.2.13", 
+        "description": "Quick tool task_falcon1_build_pdb falcon_ns.tasks.task_falcon1_build_pdb", 
+        "input_types": [
+            {
+                "description": "description for PacBio.FileTypes.json_0", 
+                "file_type_id": "PacBio.FileTypes.json", 
+                "id": "Label PacBio.FileTypes.json_0", 
+                "title": "<FileType id=PacBio.FileTypes.json name=file.json >"
+            }, 
+            {
+                "description": "description for PacBio.FileTypes.generic_fofn_1", 
+                "file_type_id": "PacBio.FileTypes.generic_fofn", 
+                "id": "Label PacBio.FileTypes.generic_fofn_1", 
+                "title": "<FileType id=PacBio.FileTypes.generic_fofn name=generic.fofn >"
+            }
+        ], 
+        "is_distributed": false, 
+        "name": "Tool task_falcon1_build_pdb", 
+        "nproc": 1, 
+        "output_types": [
+            {
+                "default_name": "run_daligner_jobs.sh", 
+                "description": "description for <FileType id=PacBio.FileTypes.txt name=file.txt >", 
+                "file_type_id": "PacBio.FileTypes.txt", 
+                "id": "Label PacBio.FileTypes.txt", 
+                "title": "<FileType id=PacBio.FileTypes.txt name=file.txt >"
+            }
+        ], 
+        "resource_types": [], 
+        "schema_options": [], 
+        "task_type": "pbsmrtpipe.task_types.standard", 
+        "tool_contract_id": "falcon_ns.tasks.task_falcon1_build_pdb"
+    }, 
+    "tool_contract_id": "falcon_ns.tasks.task_falcon1_build_pdb", 
+    "version": "0.0.0"
+}

--- a/pbsmrtpipe/registered_tool_contracts/falcon_ns.tasks.task_falcon1_run_daligner_jobs_tool_contract.json
+++ b/pbsmrtpipe/registered_tool_contracts/falcon_ns.tasks.task_falcon1_run_daligner_jobs_tool_contract.json
@@ -1,0 +1,43 @@
+{
+    "driver": {
+        "env": {}, 
+        "exe": "python -m pbsmrtpipe.pb_tasks.tasks_falcon  run-rtc  ", 
+        "serialization": "json"
+    }, 
+    "tool_contract": {
+        "_comment": "Created by v0.2.13", 
+        "description": "Quick tool task_falcon1_run_daligner_jobs falcon_ns.tasks.task_falcon1_run_daligner_jobs", 
+        "input_types": [
+            {
+                "description": "description for PacBio.FileTypes.json_0", 
+                "file_type_id": "PacBio.FileTypes.json", 
+                "id": "Label PacBio.FileTypes.json_0", 
+                "title": "<FileType id=PacBio.FileTypes.json name=file.json >"
+            }, 
+            {
+                "description": "description for PacBio.FileTypes.txt_1", 
+                "file_type_id": "PacBio.FileTypes.txt", 
+                "id": "Label PacBio.FileTypes.txt_1", 
+                "title": "<OutputFileType PacBio.FileTypes.txt Label PacBio.FileTypes.txt >"
+            }
+        ], 
+        "is_distributed": false, 
+        "name": "Tool task_falcon1_run_daligner_jobs", 
+        "nproc": 4, 
+        "output_types": [
+            {
+                "default_name": "generic.fofn", 
+                "description": "description for <FileType id=PacBio.FileTypes.generic_fofn name=generic.fofn >", 
+                "file_type_id": "PacBio.FileTypes.generic_fofn", 
+                "id": "Label PacBio.FileTypes.generic_fofn_0", 
+                "title": "<FileType id=PacBio.FileTypes.generic_fofn name=generic.fofn >"
+            }
+        ], 
+        "resource_types": [], 
+        "schema_options": [], 
+        "task_type": "pbsmrtpipe.task_types.standard", 
+        "tool_contract_id": "falcon_ns.tasks.task_falcon1_run_daligner_jobs"
+    }, 
+    "tool_contract_id": "falcon_ns.tasks.task_falcon1_run_daligner_jobs", 
+    "version": "0.0.0"
+}

--- a/pbsmrtpipe/registered_tool_contracts/falcon_ns.tasks.task_falcon1_run_merge_consensus_jobs_tool_contract.json
+++ b/pbsmrtpipe/registered_tool_contracts/falcon_ns.tasks.task_falcon1_run_merge_consensus_jobs_tool_contract.json
@@ -1,0 +1,49 @@
+{
+    "driver": {
+        "env": {}, 
+        "exe": "python -m pbsmrtpipe.pb_tasks.tasks_falcon  run-rtc  ", 
+        "serialization": "json"
+    }, 
+    "tool_contract": {
+        "_comment": "Created by v0.2.13", 
+        "description": "Quick tool task_falcon1_run_merge_consensus_jobs falcon_ns.tasks.task_falcon1_run_merge_consensus_jobs", 
+        "input_types": [
+            {
+                "description": "description for PacBio.FileTypes.json_0", 
+                "file_type_id": "PacBio.FileTypes.json", 
+                "id": "Label PacBio.FileTypes.json_0", 
+                "title": "<FileType id=PacBio.FileTypes.json name=file.json >"
+            }, 
+            {
+                "description": "description for PacBio.FileTypes.txt_1", 
+                "file_type_id": "PacBio.FileTypes.txt", 
+                "id": "Label PacBio.FileTypes.txt_1", 
+                "title": "<OutputFileType PacBio.FileTypes.txt Label PacBio.FileTypes.txt >"
+            }, 
+            {
+                "description": "description for PacBio.FileTypes.generic_fofn_2", 
+                "file_type_id": "PacBio.FileTypes.generic_fofn", 
+                "id": "Label PacBio.FileTypes.generic_fofn_2", 
+                "title": "<FileType id=PacBio.FileTypes.generic_fofn name=generic.fofn >"
+            }
+        ], 
+        "is_distributed": false, 
+        "name": "Tool task_falcon1_run_merge_consensus_jobs", 
+        "nproc": 4, 
+        "output_types": [
+            {
+                "default_name": "generic.fofn", 
+                "description": "description for <FileType id=PacBio.FileTypes.generic_fofn name=generic.fofn >", 
+                "file_type_id": "PacBio.FileTypes.generic_fofn", 
+                "id": "Label PacBio.FileTypes.generic_fofn_0", 
+                "title": "<FileType id=PacBio.FileTypes.generic_fofn name=generic.fofn >"
+            }
+        ], 
+        "resource_types": [], 
+        "schema_options": [], 
+        "task_type": "pbsmrtpipe.task_types.standard", 
+        "tool_contract_id": "falcon_ns.tasks.task_falcon1_run_merge_consensus_jobs"
+    }, 
+    "tool_contract_id": "falcon_ns.tasks.task_falcon1_run_merge_consensus_jobs", 
+    "version": "0.0.0"
+}

--- a/pbsmrtpipe/registered_tool_contracts/falcon_ns.tasks.task_falcon2_run_asm_tool_contract.json
+++ b/pbsmrtpipe/registered_tool_contracts/falcon_ns.tasks.task_falcon2_run_asm_tool_contract.json
@@ -1,0 +1,43 @@
+{
+    "driver": {
+        "env": {}, 
+        "exe": "python -m pbsmrtpipe.pb_tasks.tasks_falcon  run-rtc  ", 
+        "serialization": "json"
+    }, 
+    "tool_contract": {
+        "_comment": "Created by v0.2.13", 
+        "description": "Quick tool task_falcon2_run_asm falcon_ns.tasks.task_falcon2_run_asm", 
+        "input_types": [
+            {
+                "description": "description for PacBio.FileTypes.json_0", 
+                "file_type_id": "PacBio.FileTypes.json", 
+                "id": "Label PacBio.FileTypes.json_0", 
+                "title": "<FileType id=PacBio.FileTypes.json name=file.json >"
+            }, 
+            {
+                "description": "description for PacBio.FileTypes.generic_fofn_1", 
+                "file_type_id": "PacBio.FileTypes.generic_fofn", 
+                "id": "Label PacBio.FileTypes.generic_fofn_1", 
+                "title": "<FileType id=PacBio.FileTypes.generic_fofn name=generic.fofn >"
+            }
+        ], 
+        "is_distributed": false, 
+        "name": "Tool task_falcon2_run_asm", 
+        "nproc": 4, 
+        "output_types": [
+            {
+                "default_name": "file.fasta", 
+                "description": "description for <FileType id=PacBio.FileTypes.Fasta name=file.fasta >", 
+                "file_type_id": "PacBio.FileTypes.Fasta", 
+                "id": "Label PacBio.FileTypes.Fasta_0", 
+                "title": "<FileType id=PacBio.FileTypes.Fasta name=file.fasta >"
+            }
+        ], 
+        "resource_types": [], 
+        "schema_options": [], 
+        "task_type": "pbsmrtpipe.task_types.standard", 
+        "tool_contract_id": "falcon_ns.tasks.task_falcon2_run_asm"
+    }, 
+    "tool_contract_id": "falcon_ns.tasks.task_falcon2_run_asm", 
+    "version": "0.0.0"
+}

--- a/pbsmrtpipe/registered_tool_contracts/falcon_ns.tasks.task_falcon_config_tool_contract.json
+++ b/pbsmrtpipe/registered_tool_contracts/falcon_ns.tasks.task_falcon_config_tool_contract.json
@@ -1,0 +1,37 @@
+{
+    "driver": {
+        "env": {}, 
+        "exe": "python -m pbsmrtpipe.pb_tasks.tasks_falcon  run-rtc  ", 
+        "serialization": "json"
+    }, 
+    "tool_contract": {
+        "_comment": "Created by v0.2.13", 
+        "description": "Quick tool task_falcon_config falcon_ns.tasks.task_falcon_config", 
+        "input_types": [
+            {
+                "description": "description for PacBio.FileTypes.txt_0", 
+                "file_type_id": "PacBio.FileTypes.txt", 
+                "id": "Label PacBio.FileTypes.txt_0", 
+                "title": "<FileType id=PacBio.FileTypes.txt name=file.txt >"
+            }
+        ], 
+        "is_distributed": false, 
+        "name": "Tool task_falcon_config", 
+        "nproc": 1, 
+        "output_types": [
+            {
+                "default_name": "file.json", 
+                "description": "description for <FileType id=PacBio.FileTypes.json name=file.json >", 
+                "file_type_id": "PacBio.FileTypes.json", 
+                "id": "Label PacBio.FileTypes.json_0", 
+                "title": "<FileType id=PacBio.FileTypes.json name=file.json >"
+            }
+        ], 
+        "resource_types": [], 
+        "schema_options": [], 
+        "task_type": "pbsmrtpipe.task_types.standard", 
+        "tool_contract_id": "falcon_ns.tasks.task_falcon_config"
+    }, 
+    "tool_contract_id": "falcon_ns.tasks.task_falcon_config", 
+    "version": "0.0.0"
+}

--- a/pbsmrtpipe/registered_tool_contracts/falcon_ns.tasks.task_falcon_make_fofn_abs_tool_contract.json
+++ b/pbsmrtpipe/registered_tool_contracts/falcon_ns.tasks.task_falcon_make_fofn_abs_tool_contract.json
@@ -1,0 +1,37 @@
+{
+    "driver": {
+        "env": {}, 
+        "exe": "python -m pbsmrtpipe.pb_tasks.tasks_falcon  run-rtc  ", 
+        "serialization": "json"
+    }, 
+    "tool_contract": {
+        "_comment": "Created by v0.2.13", 
+        "description": "Quick tool task_falcon_make_fofn_abs falcon_ns.tasks.task_falcon_make_fofn_abs", 
+        "input_types": [
+            {
+                "description": "description for PacBio.FileTypes.generic_fofn_0", 
+                "file_type_id": "PacBio.FileTypes.generic_fofn", 
+                "id": "Label PacBio.FileTypes.generic_fofn_0", 
+                "title": "<FileType id=PacBio.FileTypes.generic_fofn name=generic.fofn >"
+            }
+        ], 
+        "is_distributed": false, 
+        "name": "Tool task_falcon_make_fofn_abs", 
+        "nproc": 1, 
+        "output_types": [
+            {
+                "default_name": "generic.fofn", 
+                "description": "description for <FileType id=PacBio.FileTypes.generic_fofn name=generic.fofn >", 
+                "file_type_id": "PacBio.FileTypes.generic_fofn", 
+                "id": "Label PacBio.FileTypes.generic_fofn_0", 
+                "title": "<FileType id=PacBio.FileTypes.generic_fofn name=generic.fofn >"
+            }
+        ], 
+        "resource_types": [], 
+        "schema_options": [], 
+        "task_type": "pbsmrtpipe.task_types.standard", 
+        "tool_contract_id": "falcon_ns.tasks.task_falcon_make_fofn_abs"
+    }, 
+    "tool_contract_id": "falcon_ns.tasks.task_falcon_make_fofn_abs", 
+    "version": "0.0.0"
+}

--- a/pbsmrtpipe/registered_tool_contracts/pbsmrtpipe.tools_dev.gather_run_daligner_jobs_tool_contract.json
+++ b/pbsmrtpipe/registered_tool_contracts/pbsmrtpipe.tools_dev.gather_run_daligner_jobs_tool_contract.json
@@ -1,0 +1,44 @@
+{
+    "version": "0.1.3", 
+    "driver": {
+        "serialization": "json", 
+        "exe": "python -m pbsmrtpipe.tools_dev.gather_run_daligner_jobs --resolved-tool-contract ", 
+        "env": {}
+    }, 
+    "tool_contract_id": "pbsmrtpipe.tasks.gather_run_daligner_jobs", 
+    "tool_contract": {
+        "task_type": "pbsmrtpipe.task_types.gathered", 
+        "resource_types": [], 
+        "description": "Gather Daligner Jobs", 
+        "schema_options": [], 
+        "output_types": [
+            {
+                "title": "FOFN LAS maybe?", 
+                "description": "FOFN Not Sure Yet", 
+                "default_name": "file_gathered.fofn", 
+                "id": "fofn", 
+                "file_type_id": "PacBio.FileTypes.generic_fofn"
+            }, 
+            {
+                "title": "JobDone", 
+                "description": "Job Done", 
+                "default_name": "file_gathered.txt", 
+                "id": "job_done", 
+                "file_type_id": "PacBio.FileTypes.txt"
+            }
+        ], 
+        "_comment": "Created by v0.2.13", 
+        "name": "Gather Daligner", 
+        "input_types": [
+            {
+                "description": "Fasta Gather Chunk JSON", 
+                "title": "Gather ChunkJson", 
+                "id": "cjson_in", 
+                "file_type_id": "PacBio.FileTypes.CHUNK"
+            }
+        ], 
+        "nproc": 1, 
+        "is_distributed": false, 
+        "tool_contract_id": "pbsmrtpipe.tasks.gather_run_daligner_jobs"
+    }
+}

--- a/pbsmrtpipe/registered_tool_contracts/pbsmrtpipe.tools_dev.scatter_run_daligner_jobs_tool_contract.json
+++ b/pbsmrtpipe/registered_tool_contracts/pbsmrtpipe.tools_dev.scatter_run_daligner_jobs_tool_contract.json
@@ -1,0 +1,47 @@
+{
+    "version": "0.1.3", 
+    "driver": {
+        "serialization": "json", 
+        "exe": "python -m pbsmrtpipe.tools_dev.scatter_run_daligner_jobs --resolved-tool-contract ", 
+        "env": {}
+    }, 
+    "tool_contract_id": "pbsmrtpipe.tasks.scatter_run_daligner_jobs", 
+    "tool_contract": {
+        "task_type": "pbsmrtpipe.task_types.scattered", 
+        "resource_types": [], 
+        "description": "Scatter Daligner Jobs", 
+        "schema_options": [], 
+        "output_types": [
+            {
+                "title": "Chunk JSON Filtered Fasta", 
+                "description": "Chunked JSON Filtered Fasta", 
+                "default_name": "fasta.chunked.json", 
+                "id": "cjson_out", 
+                "file_type_id": "PacBio.FileTypes.CHUNK"
+            }
+        ], 
+        "_comment": "Created by v0.2.13", 
+        "nchunks": "$max_nchunks", 
+        "name": "Scatter Daligner", 
+        "input_types": [
+            {
+                "description": "Pac Bio ???", 
+                "title": "Config", 
+                "id": "config", 
+                "file_type_id": "PacBio.FileTypes.json"
+            }, 
+            {
+                "description": "Pac Bio ???", 
+                "title": "Bash", 
+                "id": "bash", 
+                "file_type_id": "PacBio.FileTypes.txt"
+            }
+        ], 
+        "chunk_keys": [
+            "$chunk.fasta_id"
+        ], 
+        "nproc": 1, 
+        "is_distributed": false, 
+        "tool_contract_id": "pbsmrtpipe.tasks.scatter_run_daligner_jobs"
+    }
+}

--- a/pbsmrtpipe/tools_dev/gather_run_daligner_jobs.py
+++ b/pbsmrtpipe/tools_dev/gather_run_daligner_jobs.py
@@ -1,0 +1,80 @@
+import logging
+import sys
+
+from pbcommand.pb_io import load_pipeline_chunks_from_json
+
+from pbcommand.utils import setup_log
+from pbcommand.cli import pbparser_runner
+from pbcommand.models import (FileTypes, get_gather_pbparser)
+
+from pbsmrtpipe.tools.gather import (gather_fasta,
+                                     get_datum_from_chunks_by_chunk_key)
+
+log = logging.getLogger(__name__)
+
+TOOL_ID = "pbsmrtpipe.tasks.gather_run_daligner_jobs"
+CHUNK_KEY = "$chunk.daligner_job_id"
+
+
+def get_contract_parser():
+    driver = "python -m pbsmrtpipe.tools_dev.gather_run_daligner_jobs --resolved-tool-contract "
+
+    p = get_gather_pbparser(TOOL_ID, "0.1.3", "Gather Daligner",
+                            "Gather Daligner Jobs", driver, is_distributed=False)
+
+    p.add_input_file_type(FileTypes.CHUNK, "cjson_in", "Gather ChunkJson",
+                          "Fasta Gather Chunk JSON")
+
+    p.add_output_file_type(FileTypes.FOFN, "fofn", "FOFN LAS maybe?",
+                           "FOFN Not Sure Yet",
+                           "file_gathered.fofn")
+    p.add_output_file_type(FileTypes.TXT, "job_done", "JobDone",
+                           "Job Done",
+                           "file_gathered.txt")
+
+    # FIXME. There's an a bit of friction between the TC and the argrunning
+    # layer here. For nproc and nchunks, chunk-key, the values are a bit
+    # different between the two backends.
+    p.arg_parser.add_str("pbsmrtpipe.task_options.task_falcon_run_daligner_job_scatter_chunk_key", "chunk_key",
+                         "$chunk.daligner_job_id", "Chunk key", "Chunk key to use (format $chunk:{chunk-key}")
+    return p
+
+
+def run_main(chunk_json, fasta_output, chunk_key):
+    chunks = load_pipeline_chunks_from_json(chunk_json)
+
+    # Allow looseness
+    if not chunk_key.startswith('$chunk.'):
+        chunk_key = '$chunk.' + chunk_key
+        log.warn("Prepending chunk key with '$chunk.' to '{c}'".format(c=chunk_key))
+
+    fastx_files = get_datum_from_chunks_by_chunk_key(chunks, chunk_key)
+    _ = gather_fasta(fastx_files, fasta_output)
+
+    return 0
+
+
+def args_runner(args):
+    return run_main(args.cjson_in, args.fasta_out, args.chunk_key)
+
+
+def rtc_runner(rtc):
+    """
+    :type rtc: pbcommand.models.ResolvedToolContract
+    :return:
+    """
+    # the input file is just a sentinel file
+    return run_main(rtc.task.input_files[0], rtc.task.output_files[0], rtc.task.chunk_key)
+
+
+def main(argv=sys.argv):
+    mp = get_contract_parser()
+    return pbparser_runner(argv[1:],
+                           mp, args_runner,
+                           rtc_runner,
+                           log,
+                           setup_log)
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/pbsmrtpipe/tools_dev/scatter_run_daligner_jobs.py
+++ b/pbsmrtpipe/tools_dev/scatter_run_daligner_jobs.py
@@ -1,0 +1,73 @@
+import logging
+import os
+import sys
+
+from pbcore.io import FastaWriter, FastaReader
+from pbcommand.utils import setup_log
+from pbcommand.cli import pbparser_runner
+from pbcommand.models import get_scatter_pbparser, FileTypes
+
+import pbsmrtpipe.mock as M
+import pbsmrtpipe.tools.chunk_utils as CU
+
+log = logging.getLogger(__name__)
+
+TOOL_ID = "pbsmrtpipe.tasks.scatter_run_daligner_jobs"
+
+
+class Constants(object):
+    DEFAULT_NCHUNKS = 24
+    CHUNK_KEY = '$chunk.daligner_job_id'
+
+
+def get_contract_parser():
+    driver = "python -m pbsmrtpipe.tools_dev.scatter_run_daligner_jobs --resolved-tool-contract "
+
+    chunk_keys = ("$chunk.fasta_id", )
+    p = get_scatter_pbparser(TOOL_ID, "0.1.3", "Scatter Daligner",
+                             "Scatter Daligner Jobs", driver, chunk_keys,
+                             is_distributed=False)
+
+    p.add_input_file_type(FileTypes.JSON, "config", "Config",
+                          "Pac Bio ???")
+    p.add_input_file_type(FileTypes.TXT, "bash", "Bash",
+                          "Pac Bio ???")
+    p.add_output_file_type(FileTypes.CHUNK, "cjson_out", "Chunk JSON Filtered Fasta",
+                           "Chunked JSON Filtered Fasta",
+                           "fasta.chunked.json")
+    # max nchunks for this specific task
+    #p.add_int("pbsmrtpipe.task_options.dev_scatter_max_nchunks", "max_nchunks", Constants.DEFAULT_NCHUNKS,
+    #          "Max NChunks", "Maximum number of Chunks")
+    #p.add_str("pbsmrtpipe.task_options.dev_scatter_chunk_key", "chunk_key",
+    #          Constants.CHUNK_KEY, "Chunk key", "Chunk key to use (format $chunk:{chunk-key}")
+    return p
+
+
+def run_main(fasta_file, output_json, max_nchunks, chunk_key):
+    log.info("Running {f} into {n} chunks".format(f=fasta_file, n=max_nchunks))
+    output_dir = os.path.dirname(output_json)
+    CU.write_fasta_chunks_to_file(output_json, fasta_file, max_nchunks, output_dir, "scattered-daligner-jobs", "sh")
+    return 0
+
+
+def _args_run_to_random_fasta_file(args):
+    return run_main(args.fasta_in, args.cjson_out, args.max_nchunks, args.chunk_key)
+
+
+def _rtc_runner(rtc):
+    # the chunk key isn't really something that can be tweaked here.
+    return run_main(rtc.task.input_files[0], rtc.task.output_files[0], rtc.task.max_nchunks, Constants.CHUNK_KEY)
+
+
+def main(argv=sys.argv):
+    mp = get_contract_parser()
+    return pbparser_runner(argv[1:],
+                           mp,
+                           _args_run_to_random_fasta_file,
+                           _rtc_runner,
+                           log,
+                           setup_log)
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/regenerate-tool-contracts.py
+++ b/regenerate-tool-contracts.py
@@ -33,7 +33,7 @@ def _to_registry_cmd(input_file):
 def create_all_pbsmrtpipe_tcs(root_dir, output_dir):
     cmds = []
     for file_name in os.listdir(root_dir):
-        if not file_name.startswith('__'):
+        if not file_name.startswith('__') and not file_name.startswith('.'):
             name = os.path.splitext(file_name)[0]
             file_name = 'pbsmrtpipe.tools_dev.' + name + "_tool_contract.json"
             output_file = os.path.join(output_dir, file_name)
@@ -49,6 +49,7 @@ def quick_registry(output_dir):
     x = cmds.append
     x('python -m pbsmrtpipe.pb_tasks.dev emit-tool-contracts -o {o}'.format(o=output_dir))
     x('python -m pbcommand.cli.examples.dev_quick_hello_world emit-tool-contracts -o {o}'.format(o=output_dir))
+    x('python -m pbsmrtpipe.pb_tasks.tasks_falcon emit-tool-contracts -o {o}'.format(o=output_dir))
     return cmds
 
 
@@ -82,9 +83,11 @@ def create_all():
     to_cmds = [create_all_pbsmrtpipe_tcs(TASKS_ROOT, TC_DIR),
                create_pbcommand_tcs(TC_DIR),
                quick_registry(TC_DIR),
-               sa3_tool(SA3_TC_DIR)]
+               sa3_tool(SA3_TC_DIR),
+               ]
 
     cmds = itertools.chain(*to_cmds)
+    #[_run_cmd(cmd) for cmd in cmds]
     p = multiprocessing.Pool(min(multiprocessing.cpu_count(), 4))
     results = p.map(_run_cmd, cmds)
     return 0

--- a/regenerate-tool-contracts.py
+++ b/regenerate-tool-contracts.py
@@ -87,7 +87,6 @@ def create_all():
                ]
 
     cmds = itertools.chain(*to_cmds)
-    #[_run_cmd(cmd) for cmd in cmds]
     p = multiprocessing.Pool(min(multiprocessing.cpu_count(), 4))
     results = p.map(_run_cmd, cmds)
     return 0

--- a/testkit-data/.gitignore
+++ b/testkit-data/.gitignore
@@ -1,0 +1,1 @@
+job_output/

--- a/testkit-data/dev_local_chunk/makefile
+++ b/testkit-data/dev_local_chunk/makefile
@@ -1,0 +1,2 @@
+test:
+        pbtestkit-runner --log-level=DEBUG testkit.cfg

--- a/testkit-data/dev_local_chunk/makefile
+++ b/testkit-data/dev_local_chunk/makefile
@@ -1,2 +1,0 @@
-test:
-        pbtestkit-runner --log-level=DEBUG testkit.cfg

--- a/testkit-data/dev_local_fasta_chunk/makefile
+++ b/testkit-data/dev_local_fasta_chunk/makefile
@@ -1,0 +1,2 @@
+test:
+        pbtestkit-runner --log-level=DEBUG testkit.cfg

--- a/testkit-data/dev_local_fasta_chunk/makefile
+++ b/testkit-data/dev_local_fasta_chunk/makefile
@@ -1,2 +1,0 @@
-test:
-        pbtestkit-runner --log-level=DEBUG testkit.cfg


### PR DESCRIPTION
* `make test-sanity` passes.
* `smrtanalysis/siv/testkit-jobs/sa3_pipelines/falcon` passes, but only with some other libraries installed. (todo)
* Scatter/Gather here are not yet used; this is a sequential pipeline for now (at the suggestion of @nat).
* A change to regenerate-tool-contracts.py is to skip vim swap-files. (Thx, @Nat.)
* The TCs here are generated files, making the diff look much larger than it is. To keep it from being a huge diff, I have excluded the updated version numbers when TCs are regenerated. Somebody can submit that as a separate PR. (And see Issue #19.)