### PR TITLE
more IsoSeq pipeline components

### DIFF
--- a/pbsmrtpipe/chunk_operators/operator_chunk_isoseq_classify.xml
+++ b/pbsmrtpipe/chunk_operators/operator_chunk_isoseq_classify.xml
@@ -27,14 +27,14 @@
                 <chunk-key>$chunk.fasta_nfl_id</chunk-key>
                 <task-output>pbtranscript.tasks.classify:2</task-output>
             </chunk>
-            <chunk><!-- FIXME this may not do what we want -->
-                <gather-task-id>pbsmrtpipe.tasks.gather_csv</gather-task-id>
-                <chunk-key>$chunk.csv_id</chunk-key>
-                <task-output>pbtranscript.tasks.classify:3</task-output>
-            </chunk>
             <chunk>
                 <gather-task-id>pbsmrtpipe.tasks.gather_report</gather-task-id>
                 <chunk-key>$chunk.report_id</chunk-key>
+                <task-output>pbtranscript.tasks.classify:3</task-output>
+            </chunk>
+            <chunk><!-- FIXME this may not do what we want -->
+                <gather-task-id>pbsmrtpipe.tasks.gather_csv</gather-task-id>
+                <chunk-key>$chunk.csv_id</chunk-key>
                 <task-output>pbtranscript.tasks.classify:4</task-output>
             </chunk>
         </chunks>

--- a/pbsmrtpipe/chunk_operators/operator_chunk_isoseq_partial.xml
+++ b/pbsmrtpipe/chunk_operators/operator_chunk_isoseq_partial.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<chunk-operator id="pbsmrtpipe.operators.chunk_pbtranscript_ice_partial">
+
+    <task-id>pbtranscript.tasks.ice_partial</task-id>
+
+    <scatter>
+        <scatter-task-id>pbtranscript.tasks.scatter_contigset</scatter-task-id>
+        <chunks>
+            <chunk out="$chunk.contigset_id" in="pbtranscript.tasks.ice_partial:0"/>
+            <chunk out="$chunk.ref_contigset_id" in="pbtranscript.tasks.ice_partial:1"/>
+            <chunk out="$chunk.ccsset_id" in="pbtranscript.tasks.ice_partial:2"/>
+        </chunks>
+    </scatter>
+    <!-- Define the Gather Mechanism -->
+    <gather>
+        <chunks>
+            <chunk>
+                <gather-task-id>pbtranscript.tasks.gather_nfl_pickle</gather-task-id>
+                <chunk-key>$chunk.pickle_id</chunk-key>
+                <task-output>pbtranscript.tasks.ice_partial:0</task-output>
+            </chunk>
+        </chunks>
+    </gather>
+</chunk-operator>

--- a/pbsmrtpipe/registered_tool_contracts_sa3/pbtranscript.tasks.gather_nfl_pickle_tool_contract.json
+++ b/pbsmrtpipe/registered_tool_contracts_sa3/pbtranscript.tasks.gather_nfl_pickle_tool_contract.json
@@ -1,0 +1,37 @@
+{
+    "version": "0.1.0", 
+    "driver": {
+        "serialization": "json", 
+        "exe": "python -m pbtranscript.tasks.gather_nfl_pickle  --resolved-tool-contract", 
+        "env": {}
+    }, 
+    "tool_contract_id": "pbtranscript.tasks.gather_nfl_pickle", 
+    "tool_contract": {
+        "task_type": "pbsmrtpipe.task_types.gathered", 
+        "resource_types": [], 
+        "description": "General Chunk Pickle Gather", 
+        "schema_options": [], 
+        "output_types": [
+            {
+                "title": "Pickle", 
+                "description": "Gathered Pickle", 
+                "default_name": "gathered.pickle", 
+                "id": "pickle_out", 
+                "file_type_id": "PacBio.FileTypes.pickle"
+            }
+        ], 
+        "_comment": "Created by v0.2.14", 
+        "name": "Dev Pickle Gather", 
+        "input_types": [
+            {
+                "description": "Gathered CHUNK Json with Pickle chunk key", 
+                "title": "GCHUNK Json", 
+                "id": "cjson_in", 
+                "file_type_id": "PacBio.FileTypes.CHUNK"
+            }
+        ], 
+        "nproc": 1, 
+        "is_distributed": false, 
+        "tool_contract_id": "pbtranscript.tasks.gather_nfl_pickle"
+    }
+}

--- a/pbsmrtpipe/registered_tool_contracts_sa3/pbtranscript.tasks.scatter_contigset_tool_contract.json
+++ b/pbsmrtpipe/registered_tool_contracts_sa3/pbtranscript.tasks.scatter_contigset_tool_contract.json
@@ -1,0 +1,79 @@
+{
+    "version": "0.1.0", 
+    "driver": {
+        "serialization": "json", 
+        "exe": "python -m pbtranscript.tasks.scatter_contigset --resolved-tool-contract ", 
+        "env": {}
+    }, 
+    "tool_contract_id": "pbtranscript.tasks.scatter_contigset", 
+    "tool_contract": {
+        "task_type": "pbsmrtpipe.task_types.scattered", 
+        "resource_types": [], 
+        "description": "\nSpecialized ContigSet scatter, incorporating unchunked files required by\nice_partial\n", 
+        "schema_options": [
+            {
+                "pb_option": {
+                    "default": 24, 
+                    "type": "integer", 
+                    "option_id": "pbsmrtpipe.task_options.dev_scatter_max_nchunks", 
+                    "name": "Max NChunks", 
+                    "description": "Maximum number of Chunks"
+                }, 
+                "title": "JSON Schema for pbsmrtpipe.task_options.dev_scatter_max_nchunks", 
+                "required": [
+                    "pbsmrtpipe.task_options.dev_scatter_max_nchunks"
+                ], 
+                "$schema": "http://json-schema.org/draft-04/schema#", 
+                "type": "object", 
+                "properties": {
+                    "pbsmrtpipe.task_options.dev_scatter_max_nchunks": {
+                        "default": 24, 
+                        "type": "integer", 
+                        "description": "Maximum number of Chunks", 
+                        "title": "Max NChunks"
+                    }
+                }
+            }
+        ], 
+        "output_types": [
+            {
+                "title": "Chunk JSON Filtered Fasta", 
+                "description": "Chunked JSON ContigSet", 
+                "default_name": "fasta.chunked.json", 
+                "id": "cjson_out", 
+                "file_type_id": "PacBio.FileTypes.CHUNK"
+            }
+        ], 
+        "_comment": "Created by v0.2.14", 
+        "nchunks": "$max_nchunks", 
+        "name": "Scatter ContigSet", 
+        "input_types": [
+            {
+                "description": "PacBio ContigSet", 
+                "title": "ContigSet In", 
+                "id": "dataset_in", 
+                "file_type_id": "PacBio.DataSet.ContigSet"
+            }, 
+            {
+                "description": "PacBio ContigSet", 
+                "title": "Reference ContigSet", 
+                "id": "ref_in", 
+                "file_type_id": "PacBio.DataSet.ContigSet"
+            }, 
+            {
+                "description": "PacBio ConsensusRead DataSet", 
+                "title": "ConsensusReadSet", 
+                "id": "ccs_in", 
+                "file_type_id": "PacBio.DataSet.ConsensusReadSet"
+            }
+        ], 
+        "chunk_keys": [
+            "$chunk.contigset_id", 
+            "$chunk.ref_contigset_id", 
+            "$chunk.ccsset_id"
+        ], 
+        "nproc": 1, 
+        "is_distributed": false, 
+        "tool_contract_id": "pbtranscript.tasks.scatter_contigset"
+    }
+}

--- a/pbsmrtpipe/tools/chunk_utils.py
+++ b/pbsmrtpipe/tools/chunk_utils.py
@@ -160,7 +160,7 @@ def write_contigset_records(pbcore_writer_class, records, file_name):
     fasta_file_name = ".".join(file_name.split(".")[:-2]) + ".fasta"
     # XXX workaround for pbcore's FastaWriter, which won't work with the
     # IndexedFastaRecord that we might get here
-    records = [ FastaRecord(r.header, r.sequence[:]) for r in records ]
+    records = (FastaRecord(r.header, r.sequence[:]) for r in records)
     write_pbcore_records(pbcore_writer_class, records, fasta_file_name)
     log.debug("Writing ContigSet XML to {f}".format(f=file_name))
     ds = ContigSet(fasta_file_name)

--- a/pbsmrtpipe/tools/chunk_utils.py
+++ b/pbsmrtpipe/tools/chunk_utils.py
@@ -7,7 +7,7 @@ import csv
 
 from pbcore.io import (FastaWriter, FastaReader, FastqReader, FastqWriter,
                        AlignmentSet, HdfSubreadSet, SubreadSet, ReferenceSet,
-                       ConsensusReadSet, ContigSet)
+                       ConsensusReadSet, ContigSet, FastaRecord)
 from pbsmrtpipe.legacy.input_xml import fofn_to_report
 
 from pbcommand.models import PipelineChunk
@@ -158,6 +158,9 @@ def write_contigset_records(pbcore_writer_class, records, file_name):
 
     """
     fasta_file_name = ".".join(file_name.split(".")[:-2]) + ".fasta"
+    # XXX workaround for pbcore's FastaWriter, which won't work with the
+    # IndexedFastaRecord that we might get here
+    records = [ FastaRecord(r.header, r.sequence[:]) for r in records ]
     write_pbcore_records(pbcore_writer_class, records, fasta_file_name)
     log.debug("Writing ContigSet XML to {f}".format(f=file_name))
     ds = ContigSet(fasta_file_name)
@@ -165,7 +168,7 @@ def write_contigset_records(pbcore_writer_class, records, file_name):
 
 
 def __to_chunked_fastx_files(write_records_func, pbcore_reader_class, pbcore_writer_class,
-                             chunk_key, input_file, max_total_nchunks, dir_name, base_name, ext):
+                             chunk_key, input_file, max_total_nchunks, dir_name, base_name, ext, extra_chunk_keys=None):
     """Convert a Fasta/Fasta file to a chunked list of files
 
     :param write_records_func: Func(writer_class, records, file_name)
@@ -208,6 +211,8 @@ def __to_chunked_fastx_files(write_records_func, pbcore_reader_class, pbcore_wri
             total_bases = sum(len(r.sequence) for r in records)
             d = dict(total_bases=total_bases, nrecords=len(records))
             d[chunk_key] = os.path.abspath(fasta_chunk_path)
+            if extra_chunk_keys is not None:
+                d.update(extra_chunk_keys)
             c = PipelineChunk(chunk_id, **d)
             yield c
 
@@ -215,21 +220,22 @@ def __to_chunked_fastx_files(write_records_func, pbcore_reader_class, pbcore_wri
 _to_chunked_fastx_files = functools.partial(__to_chunked_fastx_files, write_pbcore_records)
 
 
-def to_chunked_fasta_files(fasta_path, max_total_nchunks, dir_name, base_name, ext):
-    return _to_chunked_fastx_files(FastaReader, FastaWriter, Constants.CHUNK_KEY_FASTA, fasta_path, max_total_nchunks, dir_name, base_name, ext)
+def to_chunked_fasta_files(fasta_path, max_total_nchunks, dir_name, base_name, ext, extra_chunk_keys=None):
+    return _to_chunked_fastx_files(FastaReader, FastaWriter, Constants.CHUNK_KEY_FASTA, fasta_path, max_total_nchunks, dir_name, base_name, ext, extra_chunk_keys=extra_chunk_keys)
 
 
-def to_chunked_fastq_files(fastq_path, max_total_nchunks, dir_name, base_name, ext):
-    return _to_chunked_fastx_files(FastqReader, FastqWriter, Constants.CHUNK_KEY_FASTQ, fastq_path, max_total_nchunks, dir_name, base_name, ext)
+def to_chunked_fastq_files(fastq_path, max_total_nchunks, dir_name, base_name, ext, extra_chunk_keys=None):
+    return _to_chunked_fastx_files(FastqReader, FastqWriter, Constants.CHUNK_KEY_FASTQ, fastq_path, max_total_nchunks, dir_name, base_name, ext, extra_chunk_keys=extra_chunk_keys)
 
 
-def to_chunked_contigset_files(dataset_path, max_total_nchunks, dir_name, base_name, ext):
-    return __to_chunked_fastx_files(write_contigset_records, ContigSet, FastaWriter, Constants.CHUNK_KEY_CONTIGSET, dataset_path, max_total_nchunks, dir_name, base_name, ext)
+def to_chunked_contigset_files(dataset_path, max_total_nchunks, dir_name, base_name, ext, extra_chunk_keys=None):
+    return __to_chunked_fastx_files(write_contigset_records, ContigSet, FastaWriter, Constants.CHUNK_KEY_CONTIGSET, dataset_path, max_total_nchunks, dir_name, base_name, ext, extra_chunk_keys=extra_chunk_keys)
 
 
-def _write_fasta_chunks_to_file(to_chunk_fastx_file_func, chunk_file, fastx_path, max_total_chunks, dir_name, chunk_base_name, chunk_ext):
+def _write_fasta_chunks_to_file(to_chunk_fastx_file_func, chunk_file, fastx_path, max_total_chunks, dir_name, chunk_base_name, chunk_ext, extra_chunk_keys=None):
     chunks = list(to_chunk_fastx_file_func(
-        fastx_path, max_total_chunks, dir_name, chunk_base_name, chunk_ext))
+        fastx_path, max_total_chunks, dir_name, chunk_base_name, chunk_ext,
+        extra_chunk_keys=extra_chunk_keys))
     write_chunks_to_json(chunks, chunk_file)
     return 0
 
@@ -242,8 +248,8 @@ def write_fastq_chunks_to_file(chunk_file, fasta_path, max_total_chunks, dir_nam
     return _write_fasta_chunks_to_file(to_chunked_fastq_files, chunk_file, fasta_path, max_total_chunks, dir_name, chunk_base_name, chunk_ext)
 
 
-def write_contigset_chunks_to_file(chunk_file, dataset_path, max_total_chunks, dir_name, chunk_base_name, chunk_ext):
-    return _write_fasta_chunks_to_file(to_chunked_contigset_files, chunk_file, dataset_path, max_total_chunks, dir_name, chunk_base_name, chunk_ext)
+def write_contigset_chunks_to_file(chunk_file, dataset_path, max_total_chunks, dir_name, chunk_base_name, chunk_ext, extra_chunk_keys=None):
+    return _write_fasta_chunks_to_file(to_chunked_contigset_files, chunk_file, dataset_path, max_total_chunks, dir_name, chunk_base_name, chunk_ext, extra_chunk_keys=extra_chunk_keys)
 
 
 def write_alignmentset_chunks_to_file(chunk_file, alignmentset_path,


### PR DESCRIPTION
I've modified chunk_utils.py to allow passing additional chunk keys through, which is used by the scatter task I'm separately adding to pbtranscript.