### PR TITLE
Update chunker calls to replace hardcoded ext 'xml'

### DIFF
--- a/pbsmrtpipe/tools/chunker.py
+++ b/pbsmrtpipe/tools/chunker.py
@@ -9,7 +9,7 @@ from pbcommand.utils import setup_log
 from pbsmrtpipe.cli_utils import main_runner_default, validate_file
 
 
-from pbcommand.models import PipelineChunk
+from pbcommand.models import PipelineChunk, FileTypes
 
 from pbcommand.models.report import Report, Attribute
 import pbsmrtpipe.tools.chunk_utils as CU
@@ -170,7 +170,8 @@ def _args_run_chunk_alignmentset(args):
                                                 args.fasta,
                                                 args.max_total_chunks,
                                                 args.output_dir,
-                                                "chunk_alignmentset", 'xml')
+                                                "chunk_alignmentset",
+                                                FileTypes.DS_ALIGN.ext)
 
 
 def _args_run_chunk_subreadset(args):
@@ -179,7 +180,8 @@ def _args_run_chunk_subreadset(args):
                                               args.fasta,
                                               args.max_total_chunks,
                                               args.output_dir,
-                                              "chunk_subreadset", 'xml')
+                                              "chunk_subreadset",
+                                              FileTypes.DS_SUBREADS.ext)
 
 
 def _add_chunk_hdfsubreadset_options(p):
@@ -200,7 +202,8 @@ def _args_run_chunk_hdfsubreadset(args):
                                                  args.hdfsubreadset,
                                                  args.max_total_chunks,
                                                  args.output_dir,
-                                                 "chunk_hdfsubreadset", 'xml')
+                                                 "chunk_hdfsubreadset",
+                                                 FileTypes.DS_SUBREADS_H5.ext)
 
 
 def _add_chunk_csv_options(p):

--- a/pbsmrtpipe/tools_dev/scatter_alignments_reference.py
+++ b/pbsmrtpipe/tools_dev/scatter_alignments_reference.py
@@ -62,7 +62,8 @@ def run_main(ds_xml, reference_set_xml, output_json, max_nchunks, output_dir):
                                          reference_set_xml,
                                          max_nchunks,
                                          output_dir,
-                                         "chunk_alignmentset", 'xml')
+                                         "chunk_alignmentset",
+                                         FileTypes.DS_ALIGN.ext)
     return 0
 
 

--- a/pbsmrtpipe/tools_dev/scatter_ccs_reference.py
+++ b/pbsmrtpipe/tools_dev/scatter_ccs_reference.py
@@ -59,7 +59,7 @@ def run_main(chunk_output_json, ccs_xml, reference_set_xml, max_nchunks, output_
                                           reference_set_xml,
                                           max_nchunks,
                                           output_dir,
-                                          "chunk_ccsset", 'xml')
+                                          "chunk_ccsset", FileTypes.DS_CCS.ext)
 
 
 def _args_runner(args):

--- a/pbsmrtpipe/tools_dev/scatter_ccs_zmws.py
+++ b/pbsmrtpipe/tools_dev/scatter_ccs_zmws.py
@@ -36,7 +36,7 @@ def run_main(chunk_output_json, dataset_xml, max_nchunks, output_dir):
         max_total_chunks=max_nchunks,
         dir_name=output_dir,
         chunk_base_name="chunk_subreadset",
-        chunk_ext='xml')
+        chunk_ext=FileTypes.DS_CCS.ext)
 
 
 def _args_runner(args):

--- a/pbsmrtpipe/tools_dev/scatter_contigset.py
+++ b/pbsmrtpipe/tools_dev/scatter_contigset.py
@@ -43,7 +43,9 @@ def get_contract_parser():
 def run_main(dataset_file, output_json, max_nchunks, chunk_key):
     log.info("Running {f} into {n} chunks".format(f=dataset_file, n=max_nchunks))
     output_dir = os.path.dirname(output_json)
-    CU.write_contigset_chunks_to_file(output_json, dataset_file, max_nchunks, output_dir, "scattered-contigset", "contigset.xml")
+    CU.write_contigset_chunks_to_file(output_json, dataset_file, max_nchunks,
+                                      output_dir, "scattered-contigset",
+                                      FileTypes.DS_CONTIG.ext)
     return 0
 
 

--- a/pbsmrtpipe/tools_dev/scatter_hdfsubreads.py
+++ b/pbsmrtpipe/tools_dev/scatter_hdfsubreads.py
@@ -50,7 +50,8 @@ def run_main(chunk_output_json, hdfsubread_xml, max_nchunks, output_dir):
     return CU.write_hdfsubreadset_chunks_to_file(chunk_output_json, hdfsubread_xml,
                                                  max_nchunks,
                                                  output_dir,
-                                                 "chunk_hdfsubreadset", 'xml')
+                                                 "chunk_hdfsubreadset",
+                                                 FileTypes.DS_SUBREADS_H5.ext)
 
 
 def _args_run_to_random_fasta_file(args):

--- a/pbsmrtpipe/tools_dev/scatter_subread_reference.py
+++ b/pbsmrtpipe/tools_dev/scatter_subread_reference.py
@@ -63,7 +63,8 @@ def run_main(chunk_output_json, subread_xml, reference_set_xml, max_nchunks, out
                                               reference_set_xml,
                                               max_nchunks,
                                               output_dir,
-                                              "chunk_subreadset", 'xml')
+                                              "chunk_subreadset",
+                                              FileTypes.DS_SUBREADS.ext)
 
 
 def _args_run_to_random_fasta_file(args):

--- a/pbsmrtpipe/tools_dev/scatter_subread_zmws.py
+++ b/pbsmrtpipe/tools_dev/scatter_subread_zmws.py
@@ -66,7 +66,7 @@ def run_main(chunk_output_json, dataset_xml, max_nchunks, output_dir):
         max_total_chunks=max_nchunks,
         dir_name=output_dir,
         chunk_base_name="chunk_dataset",
-        chunk_ext='xml')
+        chunk_ext=FileTypes.DS_SUBREADS.ext)
 
 
 def _args_runner(args):


### PR DESCRIPTION
These 'xml' extensions were hardcoded arguments to the various chunkers, and
have been replaced with the standard from pbcommand:

FileTypes.<DS_TYPE>.ext

e.g. FileTypes.DS_ALIGN.ext, which is 'alignmentset.xml'. This brings chunked
xml files in line with the extension standard and any future updates will
happen automatically.