### PR TITLE
Remove explict numpy and h5py dependencies in REQ.txt

### DIFF
--- a/PB_REQUIREMENTS.txt
+++ b/PB_REQUIREMENTS.txt
@@ -1,6 +1,4 @@
 jinja2
-numpy
-h5py
 networkx
 # Install from github
 -e git://github.com/PacificBiosciences/pbcore.git#egg=pbcore

--- a/REQUIREMENTS.txt
+++ b/REQUIREMENTS.txt
@@ -1,6 +1,4 @@
 jinja2
-numpy
-h5py
 networkx
 pbcore <= 1.2.3
 pbcommand <= 0.2.14


### PR DESCRIPTION
Default to the versions of numpy and h5py that are defined in pbcore