### PR TITLE
Explicitly pass output-dir to cluster submitted tasks

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -11,7 +11,7 @@ class Mock(MagicMock):
     def __getattr__(cls, name):
             return Mock()
 
-MOCK_MODULES = ['pbcore', 'h5py', 'numpy']
+MOCK_MODULES = ['pbcore', 'h5py', 'numpy', 'Cython', 'pysam']
 sys.modules.update((mod_name, Mock()) for mod_name in MOCK_MODULES)
 
 

--- a/pbsmrtpipe/__init__.py
+++ b/pbsmrtpipe/__init__.py
@@ -1,4 +1,4 @@
-VERSION = (0, 32, 1)
+VERSION = (0, 32, 2)
 
 
 def get_version():


### PR DESCRIPTION
- cwd for clustered submitted tasks will be the dir of the resolved tool contract (bug caught by @pb-cdunn)
- attempt to fix RTD