### PR TITLE
Add explicit option type fix tags in pipeline templates

### DIFF
--- a/pbsmrtpipe/__init__.py
+++ b/pbsmrtpipe/__init__.py
@@ -1,4 +1,4 @@
-VERSION = (0, 34, 0)
+VERSION = (0, 34, 1)
 
 
 def get_version():

--- a/pbsmrtpipe/__init__.py
+++ b/pbsmrtpipe/__init__.py
@@ -1,4 +1,4 @@
-VERSION = (0, 33, 3)
+VERSION = (0, 34, 0)
 
 
 def get_version():

--- a/pbsmrtpipe/constants.py
+++ b/pbsmrtpipe/constants.py
@@ -100,6 +100,8 @@ class PacBioNamespaces(object):
     PBSMRTPIPE_CONSTANTS_PREFIX = 'pbsmrtpipe.constants'
     # Pipelines
     PBSMRTPIPE_PIPELINES = "pbsmrtpipe.pipelines"
+    # OptionTypes (this should really be in pbcommand
+    OPTION_TYPE = "pbsmrtpipe.option_types"
 
 
 def __to_type(prefix, name):
@@ -112,3 +114,4 @@ to_task_option_ns = functools.partial(__to_type, PacBioNamespaces.PBSMRTPIPE_TAS
 to_task_ns = functools.partial(__to_type, PacBioNamespaces.PBSMRTPIPE_TASK_PREFIX)
 to_workflow_option_ns = functools.partial(__to_type, PacBioNamespaces.PBSMRTPIPE_OPTS_PREFIX)
 to_pipeline_ns = functools.partial(__to_type, PacBioNamespaces.PBSMRTPIPE_PIPELINES)
+to_opt_type_ns = functools.partial(__to_type, PacBioNamespaces.OPTION_TYPE)

--- a/pbsmrtpipe/models.py
+++ b/pbsmrtpipe/models.py
@@ -84,25 +84,31 @@ JobResources = namedtuple("JobResources", _JOB_ATTRS)
 
 
 class PacBioOption(object):
-    def __init__(self, option_id, name, default, description):
+    def __init__(self, option_id, name, default, description, pb_option_type):
         self.option_id = option_id
         self.name = name
         self.default = default
         self.description = description
+        self.pb_option_type = pb_option_type
 
     def __repr__(self):
         _d = dict(i=self.option_id,
                   n=self.name,
                   v=self.default,
-                  k=self.__class__.__name__)
-        return "<{k} {i} name: {n} default: {v} >".format(**_d)
+                  k=self.__class__.__name__,
+                  t=self.pb_option_type)
+        return "<{k} {i} name: {n} default: {v} {t} >".format(**_d)
 
     @staticmethod
     def from_dict(d):
-        return PacBioOption(d['id'], d['name'], d['default'], d['description'])
+        return PacBioOption(d['id'], d['name'], d['default'], d['description'], d['optionTypeId'])
 
     def to_dict(self):
-        return dict(id=self.option_id, name=self.name, default=self.default, description=self.description)
+        return dict(id=self.option_id,
+                    name=self.name,
+                    default=self.default,
+                    description=self.description,
+                    optionTypeId=self.pb_option_type)
 
 
 class IOBinding(object):

--- a/pbsmrtpipe/pb_io.py
+++ b/pbsmrtpipe/pb_io.py
@@ -38,7 +38,7 @@ from pbsmrtpipe.models import (SmrtAnalysisComponent, SmrtAnalysisSystem,
                                ScatterToolContractMetaTask,
                                GatherToolContractMetaTask, PacBioOption,
                                PipelineBinding, IOBinding, Pipeline)
-from pbsmrtpipe.constants import (ENV_PRESET, SEYMOUR_HOME)
+from pbsmrtpipe.constants import (ENV_PRESET, SEYMOUR_HOME,to_opt_type_ns)
 import pbsmrtpipe.constants as GlobalConstants
 from pbsmrtpipe.schemas import PT_SCHEMA, PTVR_SCHEMA
 
@@ -724,13 +724,11 @@ def _pipeline_to_task_options(rtasks, p):
 def _jschema_to_pacbio_option_type_id(jschema_type):
     # This should get pushed down into pbcommand
     # and eventually remove all of the JsonSchema models
-    def to_o(n):
-        return "pbsmrtpipe.option_types.{n}".format(n=n)
 
-    types_d = {JsonSchemaTypes.BOOL: to_o("boolean"),
-               JsonSchemaTypes.INT: to_o("integer"),
-               JsonSchemaTypes.STR: to_o("string"),
-               JsonSchemaTypes.NUM: to_o("float")}
+    types_d = {JsonSchemaTypes.BOOL: to_opt_type_ns("boolean"),
+               JsonSchemaTypes.INT: to_opt_type_ns("integer"),
+               JsonSchemaTypes.STR: to_opt_type_ns("string"),
+               JsonSchemaTypes.NUM: to_opt_type_ns("float")}
 
     if jschema_type in types_d:
         return types_d[jschema_type]
@@ -783,9 +781,8 @@ def pipeline_template_to_dict(pipeline, rtasks):
 
     all_entry_points = [_to_entry_bindings(rtasks, bs[0], bs[1]) for bs in pipeline.entry_bindings]
     entry_points_d = {d['entryId']: d for d in all_entry_points}
-    tags = ["sa3"]
     bindings = [PipelineBinding(_to_pipeline_binding(b_out),  _to_pipeline_binding(b_in)) for b_out, b_in in pipeline.bindings]
-
+    tags = list(set(pipeline.tags))
     desc = "Pipeline {i} description".format(i=pipeline.idx) if pipeline.description is None else pipeline.description
     comment = "Created pipeline {i} with pbsmrtpipe v{v}".format(i=pipeline.idx, v=pbsmrtpipe.get_version())
     return dict(id=pipeline.pipeline_id,

--- a/pbsmrtpipe/schemas/pipeline_template.avsc
+++ b/pbsmrtpipe/schemas/pipeline_template.avsc
@@ -182,6 +182,11 @@
             {
               "name": "description",
               "type": "string"
+            },
+            {
+              "name": "optionTypeId",
+              "type": "string",
+              "doc": "Explicit pacbio option type id (e.g., pacbio.option_types.boolean). This must be consistent with the 'type' field"
             }
           ]
         }

--- a/pbsmrtpipe/schemas/pipeline_template.avsc
+++ b/pbsmrtpipe/schemas/pipeline_template.avsc
@@ -143,6 +143,11 @@
             {
               "name": "description",
               "type": "string"
+            },
+            {
+              "name": "optionTypeId",
+              "type": "string",
+              "doc": "Explicit pacbio option type id (e.g., pacbio.option_types.boolean). This must be consistent with the 'type' field"
             }
           ]
         }

--- a/pbsmrtpipe/tests/data/example_pipeline_template_01.json
+++ b/pbsmrtpipe/tests/data/example_pipeline_template_01.json
@@ -31,15 +31,17 @@
       "id": "my_option",
       "name": "My Option",
       "default": 1234,
+      "optionTypeId": "pbsmrtpipe.option_types.integer",
       "description": "My Value"
     }
   ],
   "options": [
     {
-      "id": "max_nchunks",
+      "id": "pbsmrtpipe.options.max_nchunks",
       "name": "Max #Chunks",
       "default": 7,
-      "description": "Max Number of Chunks"
+      "description": "Max Number of Chunks",
+      "optionTypeId":"pbsmrtpipe.option_types.integer"
     }
   ]
 }


### PR DESCRIPTION
Adding new namespace, "pbsmrtpipe.option_types" for option types. Add explicit option type id to serialization and schema of options. This removes the casting guessing in static languages and address the JSNumber issues. Only the four option types defined in pbcommand are supported.