### PR TITLE
Add pblaa support to pbsmrtpipe

### DIFF
--- a/pbsmrtpipe/chunk_operators/operator_chunk_laa_ds.xml
+++ b/pbsmrtpipe/chunk_operators/operator_chunk_laa_ds.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<chunk-operator id="pbsmrtpipe.operators.chunk_laa_ds">
+
+    <task-id>pblaa.tasks.laa</task-id>
+
+    <scatter>
+        <scatter-task-id>pbsmrtpipe.tasks.subreadset_barcode_scatter</scatter-task-id>
+        <chunks>
+            <chunk out="$chunk.subreadset_id" in="pblaa.tasks.laa:0"/>
+        </chunks>
+    </scatter>
+    <!-- Define the Gather Mechanism -->
+    <gather>
+        <chunks>
+            <chunk>
+                <gather-task-id>pbsmrtpipe.tasks.gather_fasta</gather-task-id>
+                <chunk-key>$chunk.fasta_id</chunk-key>
+                <task-output>pblaa.tasks.laa:0</task-output>
+            </chunk>
+            <chunk>
+                <gather-task-id>pbsmrtpipe.tasks.gather_report</gather-task-id>
+                <chunk-key>$chunk.report_id</chunk-key>
+                <task-output>pblaa.tasks.laa:1</task-output>
+            </chunk>
+        </chunks>
+    </gather>
+</chunk-operator>

--- a/pbsmrtpipe/pb_pipelines/pb_pipelines_sa3.py
+++ b/pbsmrtpipe/pb_pipelines/pb_pipelines_sa3.py
@@ -257,6 +257,20 @@ def _core_export_fastx_ccs(ccs_ds):
     return b1 + b2
 
 
+def _core_laa(subread_ds):
+    # Call ccs
+    b3 = [(subread_ds, "pblaa.tasks.laa:0")]
+    return b3
+
+@register_pipeline(to_pipeline_ns("sa3_ds_laa"), "SA3 Consensus Reads", "0.1.0", tags=("laa", ))
+def ds_laa():
+    """
+    Basic Long Amplicon Analysis (LAA) pipeline, starting from subreads.
+    """
+    subreadset = Constants.ENTRY_DS_SUBREAD
+    return _core_laa(subreadset)
+
+
 def _core_ccs(subread_ds):
     # Call ccs
     b3 = [(subread_ds, "pbccs.tasks.ccs:0")]

--- a/pbsmrtpipe/registered_tool_contracts/pbsmrtpipe.tools_dev.scatter_subread_barcodes_tool_contract.json
+++ b/pbsmrtpipe/registered_tool_contracts/pbsmrtpipe.tools_dev.scatter_subread_barcodes_tool_contract.json
@@ -1,0 +1,88 @@
+{
+    "version": "0.1.3", 
+    "driver": {
+        "serialization": "json", 
+        "exe": "python -m pbsmrtpipe.tools_dev.scatter_subread_barcodes --resolved-tool-contract ", 
+        "env": {}
+    }, 
+    "tool_contract_id": "pbsmrtpipe.tasks.subreadset_barcode_scatter", 
+    "tool_contract": {
+        "task_type": "pbsmrtpipe.task_types.scattered", 
+        "resource_types": [], 
+        "description": "Scatter Subread DataSet by barcodess", 
+        "schema_options": [
+            {
+                "pb_option": {
+                    "default": 5, 
+                    "type": "integer", 
+                    "option_id": "pbsmrtpipe.task_options.scatter_subread_max_nchunks", 
+                    "name": "Max NChunks", 
+                    "description": "Maximum number of Chunks"
+                }, 
+                "title": "JSON Schema for pbsmrtpipe.task_options.scatter_subread_max_nchunks", 
+                "required": [
+                    "pbsmrtpipe.task_options.scatter_subread_max_nchunks"
+                ], 
+                "$schema": "http://json-schema.org/draft-04/schema#", 
+                "type": "object", 
+                "properties": {
+                    "pbsmrtpipe.task_options.scatter_subread_max_nchunks": {
+                        "default": 5, 
+                        "type": "integer", 
+                        "description": "Maximum number of Chunks", 
+                        "title": "Max NChunks"
+                    }
+                }
+            }, 
+            {
+                "pb_option": {
+                    "default": "$chunk:subreadset_id", 
+                    "type": "string", 
+                    "option_id": "pbsmrtpipe.task_options.scatter_subreadset_chunk_key", 
+                    "name": "Chunk key", 
+                    "description": "Chunk key to use (format $chunk:{chunk-key}"
+                }, 
+                "title": "JSON Schema for pbsmrtpipe.task_options.scatter_subreadset_chunk_key", 
+                "required": [
+                    "pbsmrtpipe.task_options.scatter_subreadset_chunk_key"
+                ], 
+                "$schema": "http://json-schema.org/draft-04/schema#", 
+                "type": "object", 
+                "properties": {
+                    "pbsmrtpipe.task_options.scatter_subreadset_chunk_key": {
+                        "default": "$chunk:subreadset_id", 
+                        "type": "string", 
+                        "description": "Chunk key to use (format $chunk:{chunk-key}", 
+                        "title": "Chunk key"
+                    }
+                }
+            }
+        ], 
+        "output_types": [
+            {
+                "title": "Chunk SubreadSet", 
+                "description": "PacBio Chunked JSON SubreadSet", 
+                "default_name": "subreadset_chunked.json", 
+                "id": "chunk_report_json", 
+                "file_type_id": "PacBio.FileTypes.CHUNK"
+            }
+        ], 
+        "_comment": "Created by v0.2.14", 
+        "nchunks": "$max_nchunks", 
+        "name": "SubreadSet barcode scatter", 
+        "input_types": [
+            {
+                "description": "Pac Bio Fasta format", 
+                "title": "SubreadSet", 
+                "id": "dataset", 
+                "file_type_id": "PacBio.DataSet.SubreadSet"
+            }
+        ], 
+        "chunk_keys": [
+            "$chunk.subreadset_id"
+        ], 
+        "nproc": 1, 
+        "is_distributed": false, 
+        "tool_contract_id": "pbsmrtpipe.tasks.subreadset_barcode_scatter"
+    }
+}

--- a/pbsmrtpipe/registered_tool_contracts_sa3/pblaa_laa_tool_contract.json
+++ b/pbsmrtpipe/registered_tool_contracts_sa3/pblaa_laa_tool_contract.json
@@ -1,0 +1,551 @@
+{
+    "version": "0.1", 
+    "driver": {
+        "serialization": "json", 
+        "exe": "task_pblaa_laa --resolved-tool-contract ", 
+        "env": {}
+    }, 
+    "tool_contract_id": "pblaa.tasks.laa", 
+    "tool_contract": {
+        "task_type": "pbsmrtpipe.task_types.standard", 
+        "resource_types": [], 
+        "description": "\nWrapper for 'laa' executable to provide tool contract interface support (and\nincidentally, using DataSet XML as input).\n", 
+        "schema_options": [
+            {
+                "pb_option": {
+                    "default": 42, 
+                    "type": "integer", 
+                    "option_id": "pblaa.task_options.rgn_seed", 
+                    "name": "RNG seed", 
+                    "description": "Modulates reservoir filtering of reads"
+                }, 
+                "title": "JSON Schema for pblaa.task_options.rgn_seed", 
+                "required": [
+                    "pblaa.task_options.rgn_seed"
+                ], 
+                "$schema": "http://json-schema.org/draft-04/schema#", 
+                "type": "object", 
+                "properties": {
+                    "pblaa.task_options.rgn_seed": {
+                        "default": 42, 
+                        "type": "integer", 
+                        "description": "Modulates reservoir filtering of reads", 
+                        "title": "RNG seed"
+                    }
+                }
+            }, 
+            {
+                "pb_option": {
+                    "default": 0, 
+                    "type": "integer", 
+                    "option_id": "pblaa.task_options.min_barcode_score", 
+                    "name": "Min barcode score", 
+                    "description": "Minimum average barcode score to require of subreads."
+                }, 
+                "title": "JSON Schema for pblaa.task_options.min_barcode_score", 
+                "required": [
+                    "pblaa.task_options.min_barcode_score"
+                ], 
+                "$schema": "http://json-schema.org/draft-04/schema#", 
+                "type": "object", 
+                "properties": {
+                    "pblaa.task_options.min_barcode_score": {
+                        "default": 0, 
+                        "type": "integer", 
+                        "description": "Minimum average barcode score to require of subreads.", 
+                        "title": "Min barcode score"
+                    }
+                }
+            }, 
+            {
+                "pb_option": {
+                    "default": 0, 
+                    "type": "integer", 
+                    "option_id": "pblaa.task_options.min_total_barcode_score", 
+                    "name": "Min total barcode score", 
+                    "description": "Minimum total barcode score to require of subreads."
+                }, 
+                "title": "JSON Schema for pblaa.task_options.min_total_barcode_score", 
+                "required": [
+                    "pblaa.task_options.min_total_barcode_score"
+                ], 
+                "$schema": "http://json-schema.org/draft-04/schema#", 
+                "type": "object", 
+                "properties": {
+                    "pblaa.task_options.min_total_barcode_score": {
+                        "default": 0, 
+                        "type": "integer", 
+                        "description": "Minimum total barcode score to require of subreads.", 
+                        "title": "Min total barcode score"
+                    }
+                }
+            }, 
+            {
+                "pb_option": {
+                    "default": 3000, 
+                    "type": "integer", 
+                    "option_id": "pblaa.task_options.min_length", 
+                    "name": "Minimum length", 
+                    "description": "Minimum length of subreads to use"
+                }, 
+                "title": "JSON Schema for pblaa.task_options.min_length", 
+                "required": [
+                    "pblaa.task_options.min_length"
+                ], 
+                "$schema": "http://json-schema.org/draft-04/schema#", 
+                "type": "object", 
+                "properties": {
+                    "pblaa.task_options.min_length": {
+                        "default": 3000, 
+                        "type": "integer", 
+                        "description": "Minimum length of subreads to use", 
+                        "title": "Minimum length"
+                    }
+                }
+            }, 
+            {
+                "pb_option": {
+                    "default": 0, 
+                    "type": "integer", 
+                    "option_id": "pblaa.task_options.max_length", 
+                    "name": "Maximum length", 
+                    "description": "Maximum length of subreads to use"
+                }, 
+                "title": "JSON Schema for pblaa.task_options.max_length", 
+                "required": [
+                    "pblaa.task_options.max_length"
+                ], 
+                "$schema": "http://json-schema.org/draft-04/schema#", 
+                "type": "object", 
+                "properties": {
+                    "pblaa.task_options.max_length": {
+                        "default": 0, 
+                        "type": "integer", 
+                        "description": "Maximum length of subreads to use", 
+                        "title": "Maximum length"
+                    }
+                }
+            }, 
+            {
+                "pb_option": {
+                    "default": 0.75, 
+                    "type": "number", 
+                    "option_id": "pblaa.task_options.min_read_score", 
+                    "name": "Min Read Score", 
+                    "description": "Minimum read score of input reads"
+                }, 
+                "title": "JSON Schema for pblaa.task_options.min_read_score", 
+                "required": [
+                    "pblaa.task_options.min_read_score"
+                ], 
+                "$schema": "http://json-schema.org/draft-04/schema#", 
+                "type": "object", 
+                "properties": {
+                    "pblaa.task_options.min_read_score": {
+                        "default": 0.75, 
+                        "type": "number", 
+                        "description": "Minimum read score of input reads", 
+                        "title": "Min Read Score"
+                    }
+                }
+            }, 
+            {
+                "pb_option": {
+                    "default": 4.0, 
+                    "type": "number", 
+                    "option_id": "pblaa.task_options.min_snr", 
+                    "name": "Minimum SNR", 
+                    "description": "Minimum SNR of input reads."
+                }, 
+                "title": "JSON Schema for pblaa.task_options.min_snr", 
+                "required": [
+                    "pblaa.task_options.min_snr"
+                ], 
+                "$schema": "http://json-schema.org/draft-04/schema#", 
+                "type": "object", 
+                "properties": {
+                    "pblaa.task_options.min_snr": {
+                        "default": 4.0, 
+                        "type": "number", 
+                        "description": "Minimum SNR of input reads.", 
+                        "title": "Minimum SNR"
+                    }
+                }
+            }, 
+            {
+                "pb_option": {
+                    "default": 2000, 
+                    "type": "integer", 
+                    "option_id": "pblaa.task_options.max_reads", 
+                    "name": "Maximum number of reads", 
+                    "description": "Maximum number of input reads to cluster per barcode"
+                }, 
+                "title": "JSON Schema for pblaa.task_options.max_reads", 
+                "required": [
+                    "pblaa.task_options.max_reads"
+                ], 
+                "$schema": "http://json-schema.org/draft-04/schema#", 
+                "type": "object", 
+                "properties": {
+                    "pblaa.task_options.max_reads": {
+                        "default": 2000, 
+                        "type": "integer", 
+                        "description": "Maximum number of input reads to cluster per barcode", 
+                        "title": "Maximum number of reads"
+                    }
+                }
+            }, 
+            {
+                "pb_option": {
+                    "default": 2.0, 
+                    "type": "number", 
+                    "option_id": "pblaa.task_options.cluster_inflation", 
+                    "name": "Cluster Infaltion", 
+                    "description": "Markov Clustering inflation parameter"
+                }, 
+                "title": "JSON Schema for pblaa.task_options.cluster_inflation", 
+                "required": [
+                    "pblaa.task_options.cluster_inflation"
+                ], 
+                "$schema": "http://json-schema.org/draft-04/schema#", 
+                "type": "object", 
+                "properties": {
+                    "pblaa.task_options.cluster_inflation": {
+                        "default": 2.0, 
+                        "type": "number", 
+                        "description": "Markov Clustering inflation parameter", 
+                        "title": "Cluster Infaltion"
+                    }
+                }
+            }, 
+            {
+                "pb_option": {
+                    "default": 1.0, 
+                    "type": "number", 
+                    "option_id": "pblaa.task_options.cluster_loop_weight", 
+                    "name": "Cluster Loop Weight", 
+                    "description": "Markov Clustering loop weight parameter"
+                }, 
+                "title": "JSON Schema for pblaa.task_options.cluster_loop_weight", 
+                "required": [
+                    "pblaa.task_options.cluster_loop_weight"
+                ], 
+                "$schema": "http://json-schema.org/draft-04/schema#", 
+                "type": "object", 
+                "properties": {
+                    "pblaa.task_options.cluster_loop_weight": {
+                        "default": 1.0, 
+                        "type": "number", 
+                        "description": "Markov Clustering loop weight parameter", 
+                        "title": "Cluster Loop Weight"
+                    }
+                }
+            }, 
+            {
+                "pb_option": {
+                    "default": 4, 
+                    "type": "integer", 
+                    "option_id": "pblaa.task_options.cluster_min_size", 
+                    "name": "Cluster Min Size", 
+                    "description": "Minimum number of members required to report cluster"
+                }, 
+                "title": "JSON Schema for pblaa.task_options.cluster_min_size", 
+                "required": [
+                    "pblaa.task_options.cluster_min_size"
+                ], 
+                "$schema": "http://json-schema.org/draft-04/schema#", 
+                "type": "object", 
+                "properties": {
+                    "pblaa.task_options.cluster_min_size": {
+                        "default": 4, 
+                        "type": "integer", 
+                        "description": "Minimum number of members required to report cluster", 
+                        "title": "Cluster Min Size"
+                    }
+                }
+            }, 
+            {
+                "pb_option": {
+                    "default": false, 
+                    "type": "boolean", 
+                    "option_id": "pblaa.task_options.no_clustering", 
+                    "name": "No Clustering", 
+                    "description": "Deactivate the coarse clustering step, go directly to fine phasing"
+                }, 
+                "title": "JSON Schema for pblaa.task_options.no_clustering", 
+                "required": [
+                    "pblaa.task_options.no_clustering"
+                ], 
+                "$schema": "http://json-schema.org/draft-04/schema#", 
+                "type": "object", 
+                "properties": {
+                    "pblaa.task_options.no_clustering": {
+                        "default": false, 
+                        "type": "boolean", 
+                        "description": "Deactivate the coarse clustering step, go directly to fine phasing", 
+                        "title": "No Clustering"
+                    }
+                }
+            }, 
+            {
+                "pb_option": {
+                    "default": 500, 
+                    "type": "integer", 
+                    "option_id": "pblaa.task_options.max_phasing_reads", 
+                    "name": "Max Phasing Reads", 
+                    "description": "Maximum number of input reads to phase per cluster"
+                }, 
+                "title": "JSON Schema for pblaa.task_options.max_phasing_reads", 
+                "required": [
+                    "pblaa.task_options.max_phasing_reads"
+                ], 
+                "$schema": "http://json-schema.org/draft-04/schema#", 
+                "type": "object", 
+                "properties": {
+                    "pblaa.task_options.max_phasing_reads": {
+                        "default": 500, 
+                        "type": "integer", 
+                        "description": "Maximum number of input reads to phase per cluster", 
+                        "title": "Max Phasing Reads"
+                    }
+                }
+            }, 
+            {
+                "pb_option": {
+                    "default": 0.1, 
+                    "type": "number", 
+                    "option_id": "pblaa.task_options.min_split_fraction", 
+                    "name": "Min Split Fraction", 
+                    "description": "Minimum fraction of reads supporting a minor phase required for split"
+                }, 
+                "title": "JSON Schema for pblaa.task_options.min_split_fraction", 
+                "required": [
+                    "pblaa.task_options.min_split_fraction"
+                ], 
+                "$schema": "http://json-schema.org/draft-04/schema#", 
+                "type": "object", 
+                "properties": {
+                    "pblaa.task_options.min_split_fraction": {
+                        "default": 0.1, 
+                        "type": "number", 
+                        "description": "Minimum fraction of reads supporting a minor phase required for split", 
+                        "title": "Min Split Fraction"
+                    }
+                }
+            }, 
+            {
+                "pb_option": {
+                    "default": 20.0, 
+                    "type": "number", 
+                    "option_id": "pblaa.task_options.min_split_reads", 
+                    "name": "Min Split Reads", 
+                    "description": "Minimum number of reads supporting a minor phase required for split"
+                }, 
+                "title": "JSON Schema for pblaa.task_options.min_split_reads", 
+                "required": [
+                    "pblaa.task_options.min_split_reads"
+                ], 
+                "$schema": "http://json-schema.org/draft-04/schema#", 
+                "type": "object", 
+                "properties": {
+                    "pblaa.task_options.min_split_reads": {
+                        "default": 20.0, 
+                        "type": "number", 
+                        "description": "Minimum number of reads supporting a minor phase required for split", 
+                        "title": "Min Split Reads"
+                    }
+                }
+            }, 
+            {
+                "pb_option": {
+                    "default": 20, 
+                    "type": "integer", 
+                    "option_id": "pblaa.task_options.ignore_ends", 
+                    "name": "Ignore Ends", 
+                    "description": "When phasing, ignore variants within N bases of the ends"
+                }, 
+                "title": "JSON Schema for pblaa.task_options.ignore_ends", 
+                "required": [
+                    "pblaa.task_options.ignore_ends"
+                ], 
+                "$schema": "http://json-schema.org/draft-04/schema#", 
+                "type": "object", 
+                "properties": {
+                    "pblaa.task_options.ignore_ends": {
+                        "default": 20, 
+                        "type": "integer", 
+                        "description": "When phasing, ignore variants within N bases of the ends", 
+                        "title": "Ignore Ends"
+                    }
+                }
+            }, 
+            {
+                "pb_option": {
+                    "default": false, 
+                    "type": "boolean", 
+                    "option_id": "pblaa.task_options.no_phasing", 
+                    "name": "No Phasing", 
+                    "description": "Deactivate the fine phasing step, go directly from clustering to consensus"
+                }, 
+                "title": "JSON Schema for pblaa.task_options.no_phasing", 
+                "required": [
+                    "pblaa.task_options.no_phasing"
+                ], 
+                "$schema": "http://json-schema.org/draft-04/schema#", 
+                "type": "object", 
+                "properties": {
+                    "pblaa.task_options.no_phasing": {
+                        "default": false, 
+                        "type": "boolean", 
+                        "description": "Deactivate the fine phasing step, go directly from clustering to consensus", 
+                        "title": "No Phasing"
+                    }
+                }
+            }, 
+            {
+                "pb_option": {
+                    "default": 0, 
+                    "type": "integer", 
+                    "option_id": "pblaa.task_options.take_n", 
+                    "name": "Take N", 
+                    "description": "Report only the top N consensus sequences for each barcode, set < 1 to disable"
+                }, 
+                "title": "JSON Schema for pblaa.task_options.take_n", 
+                "required": [
+                    "pblaa.task_options.take_n"
+                ], 
+                "$schema": "http://json-schema.org/draft-04/schema#", 
+                "type": "object", 
+                "properties": {
+                    "pblaa.task_options.take_n": {
+                        "default": 0, 
+                        "type": "integer", 
+                        "description": "Report only the top N consensus sequences for each barcode, set < 1 to disable", 
+                        "title": "Take N"
+                    }
+                }
+            }, 
+            {
+                "pb_option": {
+                    "default": 0, 
+                    "type": "integer", 
+                    "option_id": "pblaa.task_options.trim_ends", 
+                    "name": "Trim Ends", 
+                    "description": "Trim N bases from each end of each consensus"
+                }, 
+                "title": "JSON Schema for pblaa.task_options.trim_ends", 
+                "required": [
+                    "pblaa.task_options.trim_ends"
+                ], 
+                "$schema": "http://json-schema.org/draft-04/schema#", 
+                "type": "object", 
+                "properties": {
+                    "pblaa.task_options.trim_ends": {
+                        "default": 0, 
+                        "type": "integer", 
+                        "description": "Trim N bases from each end of each consensus", 
+                        "title": "Trim Ends"
+                    }
+                }
+            }, 
+            {
+                "pb_option": {
+                    "default": 0.95, 
+                    "type": "number", 
+                    "option_id": "pblaa.task_options.min_predicted_accuracy", 
+                    "name": "Min Predicted Accuracy", 
+                    "description": "Minimum predicted consensus accuracy below which a consensus is called 'Noise'"
+                }, 
+                "title": "JSON Schema for pblaa.task_options.min_predicted_accuracy", 
+                "required": [
+                    "pblaa.task_options.min_predicted_accuracy"
+                ], 
+                "$schema": "http://json-schema.org/draft-04/schema#", 
+                "type": "object", 
+                "properties": {
+                    "pblaa.task_options.min_predicted_accuracy": {
+                        "default": 0.95, 
+                        "type": "number", 
+                        "description": "Minimum predicted consensus accuracy below which a consensus is called 'Noise'", 
+                        "title": "Min Predicted Accuracy"
+                    }
+                }
+            }, 
+            {
+                "pb_option": {
+                    "default": 1.0, 
+                    "type": "number", 
+                    "option_id": "pblaa.task_options.chimera_score_threshold", 
+                    "name": "Chimera Score Threshold", 
+                    "description": "Minimum score to consider a sequence chimeric"
+                }, 
+                "title": "JSON Schema for pblaa.task_options.chimera_score_threshold", 
+                "required": [
+                    "pblaa.task_options.chimera_score_threshold"
+                ], 
+                "$schema": "http://json-schema.org/draft-04/schema#", 
+                "type": "object", 
+                "properties": {
+                    "pblaa.task_options.chimera_score_threshold": {
+                        "default": 1.0, 
+                        "type": "number", 
+                        "description": "Minimum score to consider a sequence chimeric", 
+                        "title": "Chimera Score Threshold"
+                    }
+                }
+            }, 
+            {
+                "pb_option": {
+                    "default": false, 
+                    "type": "boolean", 
+                    "option_id": "pblaa.task_options.no_chimera_filter", 
+                    "name": "No Chimera Filter", 
+                    "description": "Deactivate the chimera filter and output all consensus results"
+                }, 
+                "title": "JSON Schema for pblaa.task_options.no_chimera_filter", 
+                "required": [
+                    "pblaa.task_options.no_chimera_filter"
+                ], 
+                "$schema": "http://json-schema.org/draft-04/schema#", 
+                "type": "object", 
+                "properties": {
+                    "pblaa.task_options.no_chimera_filter": {
+                        "default": false, 
+                        "type": "boolean", 
+                        "description": "Deactivate the chimera filter and output all consensus results", 
+                        "title": "No Chimera Filter"
+                    }
+                }
+            }
+        ], 
+        "output_types": [
+            {
+                "title": "consensus_fasta_file", 
+                "description": "Resulting consensus fasta file", 
+                "default_name": "laa.fasta", 
+                "id": "consensus_fasta", 
+                "file_type_id": "PacBio.FileTypes.Fasta"
+            }, 
+            {
+                "title": "JSON report", 
+                "description": "JSON report", 
+                "default_name": "laa_report.json", 
+                "id": "report_json", 
+                "file_type_id": "PacBio.FileTypes.JsonReport"
+            }
+        ], 
+        "_comment": "Created by v0.2.14", 
+        "name": "laa", 
+        "input_types": [
+            {
+                "description": "Subread DataSet or .bam file", 
+                "title": "SubreadSet", 
+                "id": "subread_set", 
+                "file_type_id": "PacBio.DataSet.SubreadSet"
+            }
+        ], 
+        "nproc": "$max_nproc", 
+        "is_distributed": true, 
+        "tool_contract_id": "pblaa.tasks.laa"
+    }
+}

--- a/pbsmrtpipe/tools_dev/scatter_subread_barcodes.py
+++ b/pbsmrtpipe/tools_dev/scatter_subread_barcodes.py
@@ -1,0 +1,95 @@
+
+"""
+Scatter subreads by barcodes, used for input to Long Amplicon Analysis
+processing.
+"""
+
+import functools
+import logging
+import os
+import sys
+
+from pbcore.io import FastaWriter, FastaReader
+from pbcommand.utils import setup_log
+from pbcommand.cli import pbparser_runner
+from pbcommand.models import get_scatter_pbparser, FileTypes
+
+import pbsmrtpipe.mock as M
+import pbsmrtpipe.tools.chunk_utils as CU
+
+log = logging.getLogger(__name__)
+
+TOOL_ID = "pbsmrtpipe.tasks.subreadset_barcode_scatter"
+
+
+class Constants(object):
+    TOOL_ID = "pbsmrtpipe.tasks.subreadset_barcode_scatter"
+    DEFAULT_NCHUNKS = 5
+    DRIVER_EXE = "python -m pbsmrtpipe.tools_dev.scatter_subread_barcodes --resolved-tool-contract "
+    DATASET_TYPE = FileTypes.DS_SUBREADS
+    CHUNK_KEYS = ("$chunk.subreadset_id", )
+    READ_TYPE = "Subread"
+    READ_TYPE_ABBREV = "subread"
+
+def get_contract_parser_impl(C):
+    p = get_scatter_pbparser(C.TOOL_ID, "0.1.3",
+        "%sSet barcode scatter" % C.READ_TYPE,
+        "Scatter %s DataSet by barcodess" % C.READ_TYPE, C.DRIVER_EXE,
+        C.CHUNK_KEYS, is_distributed=False)
+
+    p.add_input_file_type(C.DATASET_TYPE,
+                          "dataset",
+                          "%sSet" % C.READ_TYPE,
+                          "Pac Bio Fasta format")
+
+    p.add_output_file_type(FileTypes.CHUNK,
+                           "chunk_report_json",
+                           "Chunk %sSet" % C.READ_TYPE,
+                           "PacBio Chunked JSON %sSet" % C.READ_TYPE,
+                           "%sset_chunked.json" % C.READ_TYPE_ABBREV)
+
+    # max nchunks for this specific task
+    p.add_int("pbsmrtpipe.task_options.scatter_subread_max_nchunks",
+              "max_nchunks", Constants.DEFAULT_NCHUNKS,
+              "Max NChunks", "Maximum number of Chunks")
+
+    p.add_str("pbsmrtpipe.task_options.scatter_subreadset_chunk_key",
+              "chunk_key", "$chunk:subreadset_id", "Chunk key",
+              "Chunk key to use (format $chunk:{chunk-key}")
+    return p
+
+get_contract_parser = functools.partial(get_contract_parser_impl, Constants)
+
+def run_main(chunk_output_json, dataset_xml, max_nchunks, output_dir):
+    return CU.write_subreadset_barcode_chunks_to_file(
+        chunk_file=chunk_output_json,
+        dataset_path=dataset_xml,
+        max_total_chunks=max_nchunks,
+        dir_name=output_dir,
+        chunk_base_name="chunk_dataset",
+        chunk_ext=FileTypes.DS_SUBREADS.ext)
+
+
+def _args_runner(args):
+    return run_main(args.chunk_report_json, args.subreadset,
+                    args.max_nchunks, os.path.dirname(args.chunk_report_json))
+
+
+def _rtc_runner(rtc):
+    output_dir = os.path.dirname(rtc.task.output_files[0])
+    max_nchunks = rtc.task.max_nchunks
+    return run_main(rtc.task.output_files[0], rtc.task.input_files[0],
+                    max_nchunks, output_dir)
+
+
+def main(argv=sys.argv):
+    mp = get_contract_parser()
+    return pbparser_runner(argv[1:],
+                           mp,
+                           _args_runner,
+                           _rtc_runner,
+                           log,
+                           setup_log)
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/regenerate-sa-tool-contracts.sh
+++ b/regenerate-sa-tool-contracts.sh
@@ -30,3 +30,4 @@ task_motifmaker_reprocess --emit-tool-contract > $TC_DIR/motif_maker_reprocess_t
 gffToBed --emit-tool-contract > $TC_DIR/genomic_consensus_gff2bed_tool_contract.json
 gffToVcf --emit-tool-contract > $TC_DIR/genomic_consensus_gff2vcf_tool_contract.json
 task_pbccs_ccs --emit-tool-contract > $TC_DIR/pbccs_ccs_tool_contract.json
+task_pblaa_laa --emit-tool-contract > $TC_DIR/pblaa_laa_tool_contract.json


### PR DESCRIPTION
This should add the following to pbsmrtpipe:
- The pblaa pipeline
- The pblaa chunk operator + scatter task + scatter task TCI
- The pblaa mushroom cap TCI + regeneration line

Report merging that concatenates Table with the same ID and matching Column IDs will be added to pbcommand separately.