### PR TITLE
get rid of some additional stray rst files on 'doc-clean'

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,8 @@ doc:
 	sphinx-apidoc -o docs/ pbsmrtpipe/ && cd docs/ && make html
 
 doc-clean:
+	rm docs/pbsmrtpipe*.rst
+	rm docs/modules.rst
 	cd docs && make clean
 
 unit-test:


### PR DESCRIPTION
I'm pretty certain this is harmless, but just in case...