### PR TITLE
Alternative way to get a stack-trace

### DIFF
--- a/pbsmrtpipe/engine.py
+++ b/pbsmrtpipe/engine.py
@@ -248,15 +248,21 @@ def run_command_async(command, file_stdout=None, file_stderr=None):
         sys.stderr.write("Received %r. Please wait...\n" %e)
         # Try to capture a stack-trace from the process, if Python.
         # Worst case: User can Ctrl-C again.
-        process.send_signal(signal.SIGINT)
+        #process.send_signal(signal.SIGINT) # Does not seem to be needed anymore.
         process.wait()
-        time.sleep(10)
         #slog.exception(e)  # TODO: Delete this line, when confident this is logged elsewhere.
         raise
     finally:
         # Let's be tidy and join the threads we've started.
         ##stdout_reader.join()
         ##stderr_reader.join()
+
+        # This will cause NFS to update the files,
+        # according to a friend at AMD. They had this problem in spades there.
+        os.listdir('.')
+        # But note that for us, missing output from the subproc is really no
+        # big deal. It's merely informative, and it's always available to
+        # the curious in the stdout/err files.
 
         readlines(stdout_queue, stdout_write)
         readlines(stderr_queue, stderr_write)


### PR DESCRIPTION
This is *much* simpler, and what I recommend.

Instead of fussing with async i/o, we simply tell the subprocess to write stderr/stdout into specific files. We periodically check those files for new output, like `tail -f`, and we look anything new.

Here is the result on the run which had been hanging indefinitely:
```python
 Failed to run workflow.
Traceback (most recent call last):
  File "/lustre/hpcprod/cdunn/repo/gh/FALCON-integrate/fc_env/bin/pbsmrtpipe", line 9, in <module>
    load_entry_point('pbsmrtpipe==0.34.2', 'console_scripts', 'pbsmrtpipe')()
  File "/lustre/hpcprod/cdunn/repo/gh/FALCON-integrate/pbsmrtpipe/pbsmrtpipe/cli.py", line 635, in main
    return main_runner(argv_[1:], parser, args_executer, _pbsmrtipe_setup_log, log)
  File "/lustre/hpcprod/cdunn/repo/gh/FALCON-integrate/pbsmrtpipe/pbsmrtpipe/cli_utils.py", line 120, in main_runner
    rcode = exe_runner_func(args)
  File "/lustre/hpcprod/cdunn/repo/gh/FALCON-integrate/pbsmrtpipe/pbsmrtpipe/cli_utils.py", line 89, in args_executer
    return_code = args.func(args)
  File "/lustre/hpcprod/cdunn/repo/gh/FALCON-integrate/pbsmrtpipe/pbsmrtpipe/cli.py", line 379, in _args_run_pipeline
    force_distribute=force_distribute, force_chunk_mode=force_chunk, debug_mode=args.debug)
  File "/lustre/hpcprod/cdunn/repo/gh/FALCON-integrate/pbsmrtpipe/pbsmrtpipe/driver.py", line 880, in _wrapper
    state = func(*args, **kwargs)
  File "/lustre/hpcprod/cdunn/repo/gh/FALCON-integrate/pbsmrtpipe/pbsmrtpipe/driver.py", line 977, in run_pipeline
    workflow_level_opts, output_dir, service_uri)
  File "/lustre/hpcprod/cdunn/repo/gh/FALCON-integrate/pbsmrtpipe/pbsmrtpipe/driver.py", line 847, in exe_workflow
    workers, shutdown_event, service_uri)
  File "/lustre/hpcprod/cdunn/repo/gh/FALCON-integrate/pbsmrtpipe/pbsmrtpipe/driver.py", line 466, in __exe_workflow
    _update_analysis_reports_and_datastore(tnode_, task_)
  File "/lustre/hpcprod/cdunn/repo/gh/FALCON-integrate/pbsmrtpipe/pbsmrtpipe/driver.py", line 322, in _update_analysis_reports_and_datastore
    ds_uuid = _get_dataset_uuid_or_create_uuid(path_)
  File "/lustre/hpcprod/cdunn/repo/gh/FALCON-integrate/pbsmrtpipe/pbsmrtpipe/driver.py", line 123, in _get_dataset_uuid_or_create_uuid
    ds = DataSet(path)
KeyboardInterrupt
```
Those lines appear in both the `*.stderr` file for the subprocess and in the log of the parent, where it is preceded by something like this:

    [INFO] 2015-09-27 18:13:40,585Z [status.pbsmrtpipe.engine run_command_async 195] subcommand: `pbsmrtpipe pipeline /tmp/cdunn/polished_falcon/workflow_id.xml  --debug  -e e_01:/tmp/cdunn/polished_falcon/fc_run.cfg  -e eid_subread:/mnt/secondary-siv/testdata/SA3-DS/ecoli/2590956/0003_small/Analysis_Results/m140913_222218_42240_c100699952400000001823139203261564_s1_p0.1.small.subreadset.xml --preset-xml=/tmp/cdunn/polished_falcon/preset.xml    --output-dir=/tmp/cdunn/polished_falcon/job_output` in /tmp/cdunn/polished_falcon/

This is a tremendous aid to debugging, and it suffers none of the risks of async i/o. We just read stdout/err files passively, iff they exist. Otherwise, we wait for a return-code. 