### PR TITLE
Move to openDataSet factory function

### DIFF
--- a/pbsmrtpipe/driver.py
+++ b/pbsmrtpipe/driver.py
@@ -18,7 +18,7 @@ from pbcommand.pb_io.tool_contract_io import write_resolved_tool_contract_avro
 from pbcommand.utils import log_traceback
 from pbcommand.models import (FileTypes, DataStoreFile, TaskTypes)
 
-from pbcore.io import DataSet
+from pbcore.io import openDataSet
 
 import pbsmrtpipe
 import pbsmrtpipe.constants as GlobalConstants
@@ -120,7 +120,7 @@ def _get_dataset_uuid_or_create_uuid(path):
     :return: uuid string
     """
     try:
-        ds = DataSet(path)
+        ds = openDataSet(path)
         ds_id = ds.uuid
         # make sure it's a validate uuid
         _ = uuid.UUID(ds_id)

--- a/pbsmrtpipe/registered_tool_contracts/pbsmrtpipe.tools_dev.scatter_alignments_reference_basemods_tool_contract.json
+++ b/pbsmrtpipe/registered_tool_contracts/pbsmrtpipe.tools_dev.scatter_alignments_reference_basemods_tool_contract.json
@@ -66,7 +66,7 @@
             "$chunk.reference_id"
         ], 
         "nproc": 1, 
-        "is_distributed": false, 
+        "is_distributed": true, 
         "tool_contract_id": "pbsmrtpipe.tasks.alignment_contig_scatter_basemods"
     }
 }

--- a/pbsmrtpipe/registered_tool_contracts/pbsmrtpipe.tools_dev.scatter_alignments_reference_tool_contract.json
+++ b/pbsmrtpipe/registered_tool_contracts/pbsmrtpipe.tools_dev.scatter_alignments_reference_tool_contract.json
@@ -66,7 +66,7 @@
             "$chunk.reference_id"
         ], 
         "nproc": 1, 
-        "is_distributed": false, 
+        "is_distributed": true, 
         "tool_contract_id": "pbsmrtpipe.tasks.alignment_contig_scatter"
     }
 }

--- a/pbsmrtpipe/registered_tool_contracts/pbsmrtpipe.tools_dev.scatter_subread_reference_tool_contract.json
+++ b/pbsmrtpipe/registered_tool_contracts/pbsmrtpipe.tools_dev.scatter_subread_reference_tool_contract.json
@@ -66,7 +66,7 @@
             "$chunk.subreadset_id"
         ], 
         "nproc": 1, 
-        "is_distributed": false, 
+        "is_distributed": true, 
         "tool_contract_id": "pbsmrtpipe.tasks.subreadset_align_scatter"
     }
 }

--- a/pbsmrtpipe/tools_dev/scatter_alignments_reference.py
+++ b/pbsmrtpipe/tools_dev/scatter_alignments_reference.py
@@ -31,7 +31,7 @@ def get_contract_parser(tool_id=TOOL_ID, module_name=MODULE_NAME):
                              "Pacbio DataSet AlignmentSet",
                              Constants.DRIVER_BASE.format(module=module_name),
                              Constants.CHUNK_KEYS,
-                             is_distributed=False)
+                             is_distributed=True)
 
     p.add_input_file_type(FileTypes.DS_ALIGN,
                           "alignment_ds",

--- a/pbsmrtpipe/tools_dev/scatter_subread_reference.py
+++ b/pbsmrtpipe/tools_dev/scatter_subread_reference.py
@@ -26,7 +26,7 @@ def get_contract_parser():
     chunk_keys = ("$chunk.reference_id", "$chunk.subreadset_id")
     p = get_scatter_pbparser(TOOL_ID, "0.1.3", "SubreadSet scatter",
                              "Scatter Subread DataSet", driver, chunk_keys,
-                             is_distributed=False)
+                             is_distributed=True)
 
     p.add_input_file_type(FileTypes.DS_SUBREADS,
                           "subreads",


### PR DESCRIPTION
Factory function instead of base DataSet constructor, despite needing only base DataSet functionality. The factory function checks that it is a DataSet first, allowing for fast and appropriate uuid generation.

Also moved some DataSet scatter functions to distributed instead of local by default.