### PR TITLE
propagate pbsmrtpipe.options.tmp_dir to resolved tool contracts

### DIFF
--- a/REQUIREMENTS.txt
+++ b/REQUIREMENTS.txt
@@ -1,7 +1,7 @@
 jinja2
 networkx
 pbcore <= 1.2.4
-pbcommand <= 0.2.14
+pbcommand <= 0.2.15
 pyparsing==1.5.7
 pydot
 jsonschema

--- a/pbsmrtpipe/__init__.py
+++ b/pbsmrtpipe/__init__.py
@@ -1,4 +1,4 @@
-VERSION = (0, 35, 0)
+VERSION = (0, 35, 1)
 
 
 def get_version():

--- a/pbsmrtpipe/driver.py
+++ b/pbsmrtpipe/driver.py
@@ -251,6 +251,7 @@ def __exe_workflow(global_registry, ep_d, bg, task_opts, workflow_opts, output_d
     max_nworkers = workflow_opts.max_nworkers
     max_nproc = workflow_opts.max_nproc
     max_nchunks = workflow_opts.max_nchunks
+    tmp_dir = workflow_opts.tmp_dir
 
     q_out = multiprocessing.Queue()
 
@@ -552,12 +553,12 @@ def __exe_workflow(global_registry, ep_d, bg, task_opts, workflow_opts, output_d
                     # the task.options have actually already been resolved here, but using this other
                     # code path for clarity
                     if isinstance(tnode.meta_task, ToolContractMetaTask):
-                        rtc = IO.static_meta_task_to_rtc(tnode.meta_task, task, task_opts, task_dir, '/tmp', max_nproc)
+                        rtc = IO.static_meta_task_to_rtc(tnode.meta_task, task, task_opts, task_dir, tmp_dir, max_nproc)
                     elif isinstance(tnode.meta_task, ScatterToolContractMetaTask):
-                        rtc = IO.static_scatter_meta_task_to_rtc(tnode.meta_task, task, task_opts, task_dir, '/tmp', max_nproc, max_nchunks, tnode.meta_task.chunk_keys)
+                        rtc = IO.static_scatter_meta_task_to_rtc(tnode.meta_task, task, task_opts, task_dir, tmp_dir, max_nproc, max_nchunks, tnode.meta_task.chunk_keys)
                     elif isinstance(tnode.meta_task, GatherToolContractMetaTask):
                         # this should always be a TaskGatherBindingNode which will have a .chunk_key
-                        rtc = IO.static_gather_meta_task_to_rtc(tnode.meta_task, task, task_opts, task_dir, '/tmp', max_nproc, tnode.chunk_key)
+                        rtc = IO.static_gather_meta_task_to_rtc(tnode.meta_task, task, task_opts, task_dir, tmp_dir, max_nproc, tnode.chunk_key)
                     else:
                         raise TypeError("Unsupported task type {t}".format(t=tnode.meta_task))
 


### PR DESCRIPTION
This gets the minimal implementation working - if I put this in my preset.xml:

        <option id="pbsmrtpipe.options.tmp_dir">
            <value>/scratch</value>
        </option>

I get this in resolved-tool-contract.json:

        "resources": [
            {
                "path": "/scratch",
                "type_id": "$tmpdir"
            }
        ],

(the default value is unchanged)

I think I figured out that the tool contract is supposed to specify the expected resource_types and these will be filled in in the resolved tool contract, but I didn't see any machinery to handle this in pbcommand.  And it will require some refactoring of pbsmrtpipe internals to get support for multiple temporary directories and files.  It was unclear what the relative priority of these features was.