### PR TITLE
Undrop defaults

### DIFF
--- a/pbsmrtpipe/registered_tool_contracts_sa3/falcon_ns.tasks.task_falcon_get_config_tool_contract.json
+++ b/pbsmrtpipe/registered_tool_contracts_sa3/falcon_ns.tasks.task_falcon_get_config_tool_contract.json
@@ -28,7 +28,307 @@
             }
         ],
         "resource_types": [],
-        "schema_options": [],
+        "schema_options": [
+            {
+                "$schema": "http://json-schema.org/draft-04/schema#",
+                "pb_option": {
+                    "default": "32",
+                    "description": "Option pa_concurrent_jobs description",
+                    "name": "Option pa_concurrent_jobs",
+                    "option_id": "falcon_ns.task_options.pa_concurrent_jobs",
+                    "type": "string"
+                },
+                "properties": {
+                    "falcon_ns.task_options.pa_concurrent_jobs": {
+                        "default": "32",
+                        "description": "Option pa_concurrent_jobs description",
+                        "title": "Option pa_concurrent_jobs",
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "falcon_ns.task_options.pa_concurrent_jobs"
+                ],
+                "title": "JSON Schema for falcon_ns.task_options.pa_concurrent_jobs",
+                "type": "object"
+            },
+            {
+                "$schema": "http://json-schema.org/draft-04/schema#",
+                "pb_option": {
+                    "default": "32",
+                    "description": "Option ovlp_concurrent_jobs description",
+                    "name": "Option ovlp_concurrent_jobs",
+                    "option_id": "falcon_ns.task_options.ovlp_concurrent_jobs",
+                    "type": "string"
+                },
+                "properties": {
+                    "falcon_ns.task_options.ovlp_concurrent_jobs": {
+                        "default": "32",
+                        "description": "Option ovlp_concurrent_jobs description",
+                        "title": "Option ovlp_concurrent_jobs",
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "falcon_ns.task_options.ovlp_concurrent_jobs"
+                ],
+                "title": "JSON Schema for falcon_ns.task_options.ovlp_concurrent_jobs",
+                "type": "object"
+            },
+            {
+                "$schema": "http://json-schema.org/draft-04/schema#",
+                "pb_option": {
+                    "default": "1",
+                    "description": "Option length_cutoff description",
+                    "name": "Option length_cutoff",
+                    "option_id": "falcon_ns.task_options.length_cutoff",
+                    "type": "string"
+                },
+                "properties": {
+                    "falcon_ns.task_options.length_cutoff": {
+                        "default": "1",
+                        "description": "Option length_cutoff description",
+                        "title": "Option length_cutoff",
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "falcon_ns.task_options.length_cutoff"
+                ],
+                "title": "JSON Schema for falcon_ns.task_options.length_cutoff",
+                "type": "object"
+            },
+            {
+                "$schema": "http://json-schema.org/draft-04/schema#",
+                "pb_option": {
+                    "default": "-x5 -s50 -a",
+                    "description": "Option pa_dbsplit_option description",
+                    "name": "Option pa_dbsplit_option",
+                    "option_id": "falcon_ns.task_options.pa_dbsplit_option",
+                    "type": "string"
+                },
+                "properties": {
+                    "falcon_ns.task_options.pa_dbsplit_option": {
+                        "default": "-x5 -s50 -a",
+                        "description": "Option pa_dbsplit_option description",
+                        "title": "Option pa_dbsplit_option",
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "falcon_ns.task_options.pa_dbsplit_option"
+                ],
+                "title": "JSON Schema for falcon_ns.task_options.pa_dbsplit_option",
+                "type": "object"
+            },
+            {
+                "$schema": "http://json-schema.org/draft-04/schema#",
+                "pb_option": {
+                    "default": "IGNORE2",
+                    "description": "Option sge_option_la description",
+                    "name": "Option sge_option_la",
+                    "option_id": "falcon_ns.task_options.sge_option_la",
+                    "type": "string"
+                },
+                "properties": {
+                    "falcon_ns.task_options.sge_option_la": {
+                        "default": "IGNORE2",
+                        "description": "Option sge_option_la description",
+                        "title": "Option sge_option_la",
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "falcon_ns.task_options.sge_option_la"
+                ],
+                "title": "JSON Schema for falcon_ns.task_options.sge_option_la",
+                "type": "object"
+            },
+            {
+                "$schema": "http://json-schema.org/draft-04/schema#",
+                "pb_option": {
+                    "default": "-v -k25 -h35 -w5 -H1000 -e.99 -l40 -s1000 -t27",
+                    "description": "Option ovlp_hpcdaligner_option description",
+                    "name": "Option ovlp_hpcdaligner_option",
+                    "option_id": "falcon_ns.task_options.ovlp_hpcdaligner_option",
+                    "type": "string"
+                },
+                "properties": {
+                    "falcon_ns.task_options.ovlp_hpcdaligner_option": {
+                        "default": "-v -k25 -h35 -w5 -H1000 -e.99 -l40 -s1000 -t27",
+                        "description": "Option ovlp_hpcdaligner_option description",
+                        "title": "Option ovlp_hpcdaligner_option",
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "falcon_ns.task_options.ovlp_hpcdaligner_option"
+                ],
+                "title": "JSON Schema for falcon_ns.task_options.ovlp_hpcdaligner_option",
+                "type": "object"
+            },
+            {
+                "$schema": "http://json-schema.org/draft-04/schema#",
+                "pb_option": {
+                    "default": "--output_multi --min_idt 0.70 --min_cov 1 --local_match_count_threshold 100 --max_n_read 20000 --n_core 6",
+                    "description": "Option falcon_sense_option description",
+                    "name": "Option falcon_sense_option",
+                    "option_id": "falcon_ns.task_options.falcon_sense_option",
+                    "type": "string"
+                },
+                "properties": {
+                    "falcon_ns.task_options.falcon_sense_option": {
+                        "default": "--output_multi --min_idt 0.70 --min_cov 1 --local_match_count_threshold 100 --max_n_read 20000 --n_core 6",
+                        "description": "Option falcon_sense_option description",
+                        "title": "Option falcon_sense_option",
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "falcon_ns.task_options.falcon_sense_option"
+                ],
+                "title": "JSON Schema for falcon_ns.task_options.falcon_sense_option",
+                "type": "object"
+            },
+            {
+                "$schema": "http://json-schema.org/draft-04/schema#",
+                "pb_option": {
+                    "default": "IGNORE1",
+                    "description": "Option sge_option_da description",
+                    "name": "Option sge_option_da",
+                    "option_id": "falcon_ns.task_options.sge_option_da",
+                    "type": "string"
+                },
+                "properties": {
+                    "falcon_ns.task_options.sge_option_da": {
+                        "default": "IGNORE1",
+                        "description": "Option sge_option_da description",
+                        "title": "Option sge_option_da",
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "falcon_ns.task_options.sge_option_da"
+                ],
+                "title": "JSON Schema for falcon_ns.task_options.sge_option_da",
+                "type": "object"
+            },
+            {
+                "$schema": "http://json-schema.org/draft-04/schema#",
+                "pb_option": {
+                    "default": "--max_diff 10000 --max_cov 100000 --min_cov 0 --bestn 1000 --n_core 4",
+                    "description": "Option overlap_filtering_setting description",
+                    "name": "Option overlap_filtering_setting",
+                    "option_id": "falcon_ns.task_options.overlap_filtering_setting",
+                    "type": "string"
+                },
+                "properties": {
+                    "falcon_ns.task_options.overlap_filtering_setting": {
+                        "default": "--max_diff 10000 --max_cov 100000 --min_cov 0 --bestn 1000 --n_core 4",
+                        "description": "Option overlap_filtering_setting description",
+                        "title": "Option overlap_filtering_setting",
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "falcon_ns.task_options.overlap_filtering_setting"
+                ],
+                "title": "JSON Schema for falcon_ns.task_options.overlap_filtering_setting",
+                "type": "object"
+            },
+            {
+                "$schema": "http://json-schema.org/draft-04/schema#",
+                "pb_option": {
+                    "default": "1",
+                    "description": "Option length_cutoff_pr description",
+                    "name": "Option length_cutoff_pr",
+                    "option_id": "falcon_ns.task_options.length_cutoff_pr",
+                    "type": "string"
+                },
+                "properties": {
+                    "falcon_ns.task_options.length_cutoff_pr": {
+                        "default": "1",
+                        "description": "Option length_cutoff_pr description",
+                        "title": "Option length_cutoff_pr",
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "falcon_ns.task_options.length_cutoff_pr"
+                ],
+                "title": "JSON Schema for falcon_ns.task_options.length_cutoff_pr",
+                "type": "object"
+            },
+            {
+                "$schema": "http://json-schema.org/draft-04/schema#",
+                "pb_option": {
+                    "default": "-x5 -s50 -a",
+                    "description": "Option ovlp_dbsplit_option description",
+                    "name": "Option ovlp_dbsplit_option",
+                    "option_id": "falcon_ns.task_options.ovlp_dbsplit_option",
+                    "type": "string"
+                },
+                "properties": {
+                    "falcon_ns.task_options.ovlp_dbsplit_option": {
+                        "default": "-x5 -s50 -a",
+                        "description": "Option ovlp_dbsplit_option description",
+                        "title": "Option ovlp_dbsplit_option",
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "falcon_ns.task_options.ovlp_dbsplit_option"
+                ],
+                "title": "JSON Schema for falcon_ns.task_options.ovlp_dbsplit_option",
+                "type": "object"
+            },
+            {
+                "$schema": "http://json-schema.org/draft-04/schema#",
+                "pb_option": {
+                    "default": "nodefault",
+                    "description": "Option input_fofn description",
+                    "name": "Option input_fofn",
+                    "option_id": "falcon_ns.task_options.input_fofn",
+                    "type": "string"
+                },
+                "properties": {
+                    "falcon_ns.task_options.input_fofn": {
+                        "default": "nodefault",
+                        "description": "Option input_fofn description",
+                        "title": "Option input_fofn",
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "falcon_ns.task_options.input_fofn"
+                ],
+                "title": "JSON Schema for falcon_ns.task_options.input_fofn",
+                "type": "object"
+            },
+            {
+                "$schema": "http://json-schema.org/draft-04/schema#",
+                "pb_option": {
+                    "default": "-v -k25 -h35 -w5 -H1000 -e.95 -l40 -s1000 -t27",
+                    "description": "Option pa_hpcdaligner_option description",
+                    "name": "Option pa_hpcdaligner_option",
+                    "option_id": "falcon_ns.task_options.pa_hpcdaligner_option",
+                    "type": "string"
+                },
+                "properties": {
+                    "falcon_ns.task_options.pa_hpcdaligner_option": {
+                        "default": "-v -k25 -h35 -w5 -H1000 -e.95 -l40 -s1000 -t27",
+                        "description": "Option pa_hpcdaligner_option description",
+                        "title": "Option pa_hpcdaligner_option",
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "falcon_ns.task_options.pa_hpcdaligner_option"
+                ],
+                "title": "JSON Schema for falcon_ns.task_options.pa_hpcdaligner_option",
+                "type": "object"
+            }
+        ],
         "task_type": "pbsmrtpipe.task_types.standard",
         "tool_contract_id": "falcon_ns.tasks.task_falcon_get_config"
     },


### PR DESCRIPTION
People want a default GUI workflow, so we need defaults.

This works in my local test. This took longer to do than I expected b/c I cannot test it by re-running only a specific task. The workflow generates the resolved-tool-contracts, so I have to make a change, re-generated the unresolved tool-contracts, and re-run the whole flow, and I didn't realize that at first.

Some of these settings are not really needed, but currently we share a config-validator with pypeflow.

See
  http://bugzilla.nanofluidics.com/show_bug.cgi?id=28896