### PR TITLE
Propagate Cluster stderr. Support for Fasta convert/import in ServiceAccessLayer

### DIFF
--- a/pbsmrtpipe/__init__.py
+++ b/pbsmrtpipe/__init__.py
@@ -1,4 +1,4 @@
-VERSION = (0, 35, 7)
+VERSION = (0, 35, 8)
 
 
 def get_version():

--- a/pbsmrtpipe/__init__.py
+++ b/pbsmrtpipe/__init__.py
@@ -1,4 +1,4 @@
-VERSION = (0, 35, 6)
+VERSION = (0, 35, 7)
 
 
 def get_version():

--- a/pbsmrtpipe/driver.py
+++ b/pbsmrtpipe/driver.py
@@ -470,14 +470,11 @@ def __exe_workflow(global_registry, ep_d, bg, task_opts, workflow_opts, output_d
                 else:
                     # Process Non-Successful Task Result
                     B.update_task_state(bg, tnode_, state_)
-                    msg_ = "Task was not successful {r}".format(r=result)
-                    slog.error(msg_)
-                    log.error(msg_ + "\n")
-                    sys.stderr.write(msg_ + "\n")
+                    slog.error(result.error_message)
+                    log.error(result.error_message + "\n")
+                    sys.stderr.write(result.error_message + "\n")
 
-                    stderr_ = os.path.join(task_.output_dir, "stderr")
-
-                    _log_task_failure_and_call_services(stderr_, tid_)
+                    _log_task_failure_and_call_services(result.error_message, tid_)
 
                     # let the remaining running jobs continue
                     w_ = workers.pop(tid_)

--- a/pbsmrtpipe/engine.py
+++ b/pbsmrtpipe/engine.py
@@ -67,7 +67,7 @@ def backticks(cmd, merge_stderr=True):
     else:
         msg = "Return code {r} {e} of cmd {c}".format(r=p.returncode, e=errorMessage, c=cmd)
         log.error(msg)
-        sys.stderr.write(msg)
+        sys.stderr.write(msg + "\n")
 
     return errCode, output, errorMessage, run_time
 

--- a/pbsmrtpipe/services.py
+++ b/pbsmrtpipe/services.py
@@ -274,17 +274,47 @@ class ServiceAccessLayer(object):
         ds_endpoint = _get_endpoint_or_raise(dataset_type)
         return _process_rget(_null_func)(_to_url(self.uri, "/secondary-analysis/datasets/{t}/{i}".format(t=ds_endpoint, i=int_or_uuid)))
 
+    def _get_datasets_by_type(self, dstype):
+        return _process_rget(_null_func)(_to_url(self.uri, "/secondary-analysis/datasets/{i}".format(i=dstype)))
+
     def get_subreadset_by_id(self, int_or_uuid):
         return self.get_dataset_by_id(DataSetMetaTypes.SUBREAD, int_or_uuid)
+
+    def get_subreadsets(self):
+        return self._get_datasets_by_type("subreads")
 
     def get_hdfsubreadset_by_id(self, int_or_uuid):
         return self.get_dataset_by_id(DataSetMetaTypes.HDF_SUBREAD, int_or_uuid)
 
+    def get_hdfsubreadsets(self):
+        return self._get_datasets_by_type("hdfsubreads")
+
     def get_referenceset_by_id(self, int_or_uuid):
         return self.get_dataset_by_id(DataSetMetaTypes.REFERENCE, int_or_uuid)
 
+    def get_referencesets(self):
+        return self._get_datasets_by_type("references")
+
     def get_alignmentset_by_id(self, int_or_uuid):
         return self.get_dataset_by_id(DataSetMetaTypes.ALIGNMENT, int_or_uuid)
+
+    def get_alignmentsets(self):
+        return self._get_datasets_by_type("alignments")
+
+    def import_fasta(self, fasta_path, name, organism, ploidy):
+        """Convert fasta file to a ReferenceSet and Import. Returns a Job """
+        d = dict(path=fasta_path,
+                 name=name,
+                 organism=organism,
+                 ploidy=ploidy)
+
+        return _process_rpost(_null_func)(self._to_url("/secondary-analysis/job-manager/jobs/convert-fasta-reference"), d)
+
+    def run_import_fasta(self, fasta_path, name, organism, ploidy):
+        """Import a Reference into a Block"""""
+        job = self.import_fasta(fasta_path, name, organism, ploidy)
+        job_id = job['id']
+        return _block_for_job_to_complete(self, job_id)
 
     def create_logger_resource(self, idx, name, description):
         _d = dict(id=idx, name=name, description=description)

--- a/pbsmrtpipe/utils.py
+++ b/pbsmrtpipe/utils.py
@@ -56,7 +56,27 @@ def _nfs_exists_check(ff):
     # this is taken from Yuan
     cmd = "ls %s" % ff
     output, errCode, errMsg = backticks(cmd)
+
+    try:
+        os.path.abspath(ff)
+    except:
+        pass
+
     return errCode == 0
+
+
+def nfs_refresh(path, ntimes=3):
+    if os.path.exists(path):
+        return True
+
+    # re-try
+    for i in xrange(ntimes):
+        if _nfs_exists_check(path):
+            return True
+        #
+        time.sleep(1.0)
+    log.warn("NFS refresh failed. unable to resolve {p}".format(p=path))
+    return False
 
 
 def validate_fofn(fofn):


### PR DESCRIPTION
- Improved Cluster stderr propagation
- Better NFS checks/refresh
- Use abspath in pbtools-runner


-ServiceAccessLayer
- get "alls" for core dataset types 
- Job type: convert import fasta support