### PR TITLE
Update to LSF bsub/bkill arguments

### DIFF
--- a/pbsmrtpipe/cluster_templates/lsf/start.tmpl
+++ b/pbsmrtpipe/cluster_templates/lsf/start.tmpl
@@ -1,1 +1,1 @@
-bsub -Is -J ${JOB_ID} -o ${STDOUT_FILE} -e ${STDERR_FILE} -n ${NPROC} ${CMD}
+bsub -Is -J ${JOB_ID} -o ${STDOUT_FILE} -e ${STDERR_FILE} -n ${NPROC} -q interactive ${CMD}

--- a/pbsmrtpipe/cluster_templates/lsf/stop.tmpl
+++ b/pbsmrtpipe/cluster_templates/lsf/stop.tmpl
@@ -1,3 +1,1 @@
-. /opt/lsf/conf/profile.lsf
 bkill -J ${JOB_ID}
-


### PR DESCRIPTION
Basically you shouldn't/can't source an rc file in a template, and I also added a queue setup that works for me in my openlava instances. (since this is a demo)