### PR TITLE
Sync file from nfs

### DIFF
--- a/pbsmrtpipe/cli_utils.py
+++ b/pbsmrtpipe/cli_utils.py
@@ -7,42 +7,13 @@ import traceback
 
 
 from pbcore.util.Process import backticks
-from pbsmrtpipe.utils import setup_log
+from pbsmrtpipe.utils import setup_log, nfs_exists_check
 
 log = logging.getLogger(__name__)
 
 
 def trigger_nfs_refresh(ff):
-    """
-    Central place for all NFS hackery
-
-    Return whether a file or a dir ff exists or not.
-    Call ls instead of python os.path.exists to eliminate NFS errors.
-
-    Added try/catch black hole exception cases to help trigger an NFS refresh
-
-    :rtype bool:
-    """
-    # try to trigger refresh for File case
-    try:
-        f = open(ff, 'r')
-        f.close()
-    except Exception:
-        pass
-
-    # try to trigger refresh for Directory case
-    try:
-        _ = os.stat(ff)
-        _ = os.listdir(ff)
-    except Exception:
-        pass
-
-    # Call externally
-    # this is taken from Yuan
-    cmd = "ls %s" % ff
-    _, rcode, _ = backticks(cmd)
-
-    return rcode == 0
+    return nfs_exists_check(ff)
 
 
 def _trigger_nfs_refresh_and_ignore(ff):

--- a/pbsmrtpipe/driver.py
+++ b/pbsmrtpipe/driver.py
@@ -144,6 +144,7 @@ def _get_last_lines_of_stderr(n, stderr_path):
     """
     lines = []
     try:
+        os.listdir(os.path.dirname(os.path.realpath(stderr_path))) # to force nfs sync
         with open(stderr_path, 'r') as f:
             lines = deque(f, n)
             lines = [l.rstrip() for l in lines]

--- a/pbsmrtpipe/driver.py
+++ b/pbsmrtpipe/driver.py
@@ -19,6 +19,7 @@ from pbcommand.pb_io import write_resolved_tool_contract, write_tool_contract
 from pbcommand.pb_io.tool_contract_io import write_resolved_tool_contract_avro
 from pbcommand.utils import log_traceback
 from pbcommand.models import (FileTypes, DataStoreFile, TaskTypes)
+from pbsmrtpipe.utils import nfs_exists_check
 
 from pbcore.io import openDataSet
 
@@ -144,12 +145,12 @@ def _get_last_lines_of_stderr(n, stderr_path):
     """
     lines = []
     try:
-        os.listdir(os.path.dirname(os.path.realpath(stderr_path))) # to force nfs sync
+        nfs_exists_check(stderr_path)
         with open(stderr_path, 'r') as f:
             lines = deque(f, n)
             lines = [l.rstrip() for l in lines]
     except Exception as e:
-        log.warn("Unable to extract stderr from {p} Error {e}".format(p=stderr_path, e=e.message))
+        log.exception("Unable to extract stderr from {p} Error {e}".format(p=stderr_path, e=e.message))
 
     return lines
 

--- a/pbsmrtpipe/tools/runner.py
+++ b/pbsmrtpipe/tools/runner.py
@@ -19,6 +19,7 @@ from pbsmrtpipe.cluster import Constants as ClusterConstants
 from pbsmrtpipe.engine import run_command, backticks
 from pbsmrtpipe.models import RunnableTask, TaskStates
 from pbcommand.models import ResourceTypes, TaskTypes
+from pbsmrtpipe.utils import nfs_exists_check
 import pbsmrtpipe.pb_io as IO
 
 import pbsmrtpipe.tools.utils as U
@@ -239,7 +240,7 @@ def run_task(runnable_task, output_dir, task_stdout, task_stderr, debug_mode):
                 rcode, out, error, run_time = run_command(cmd, stdout_fh, stderr_fh, time_out=None)
 
                 if rcode != 0:
-                    err_msg_ = "Failed task {i} exit code {r} in {s:.2f} sec".format(i=runnable_task.task.task_id, r=rcode, s=run_time)
+                    err_msg_ = "Failed task {i} exit code {r} in {s:.2f} sec (See file '{f}'.)".format(i=runnable_task.task.task_id, r=rcode, s=run_time, f=task_stderr)
                     t_error_msg = _extract_last_nlines(task_stderr)
                     err_msg = "\n".join([err_msg_, t_error_msg])
                     log.error(err_msg)
@@ -310,12 +311,12 @@ def _extract_last_nlines(path, nlines=25):
     """
     try:
         n = nlines + 1
-        os.listdir(os.path.dirname(os.path.realpath(path))) # to force nfs sync
+        nfs_exists_check(path)
         with open(path, 'r') as f:
             s = f.readlines()
             return "\n".join(s[-1: n])
     except Exception as e:
-        log.warn("Unable to extract stderr from {p}. {e}".format(p=path, e=e))
+        log.exception("Unable to extract stderr from {p}. {e}".format(p=path, e=e))
         return ""
 
 

--- a/pbsmrtpipe/tools/runner.py
+++ b/pbsmrtpipe/tools/runner.py
@@ -310,6 +310,7 @@ def _extract_last_nlines(path, nlines=25):
     """
     try:
         n = nlines + 1
+        os.listdir(os.path.dirname(os.path.realpath(path))) # to force nfs sync
         with open(path, 'r') as f:
             s = f.readlines()
             return "\n".join(s[-1: n])


### PR DESCRIPTION
Syncing stderr from nfs is sometimes slow.
```
[INFO] 2015-11-05 14:51:34,380Z [pbcommand.models.report write_json 687] Wrote report /pbi/dept/secondary/siv/smrtlink/smrtlink-bihourly/smrtsuite/userdata/jobs_root/000/000064/workflow/report-tasks.json
[ERROR] 2015-11-05 14:51:34,391Z [status.pbsmrtpipe.driver __exe_workflow 484] Failed with exit code 1
[ERROR] 2015-11-05 14:51:34,393Z [pbsmrtpipe.driver __exe_workflow 485] Failed with exit code 1

[WARNING] 2015-11-05 14:51:34,395Z [pbsmrtpipe.driver _get_last_lines_of_stderr 151] Unable to extract stderr from Failed with exit code 1 Error 
```
Calling os.listdir() might solve this.

(Discussed with @gconcepcion.)