### PR TITLE
Tune ccs parameters for isoseq.

### DIFF
--- a/pbsmrtpipe/pb_pipelines/pb_pipelines_sa3.py
+++ b/pbsmrtpipe/pb_pipelines/pb_pipelines_sa3.py
@@ -449,8 +449,8 @@ ISOSEQ_TASK_OPTIONS = {
     "pbccs.task_options.min_passes":1,
     "pbccs.task_options.min_length":300,
     "pbccs.task_options.min_zscore":-9999,
-    "pbccs.task_options.max_drop_fraction":1.0,
-    "pbccs.task_options.min_predicted_accuracy":0.75
+    "pbccs.task_options.max_drop_fraction":0.80,
+    "pbccs.task_options.min_predicted_accuracy":0.80
 }
 
 


### PR DESCRIPTION
bug 28239

Use slightly more stringent ccs parameters.