### PR TITLE
SMP style host allocation under LSF.

### DIFF
--- a/pbsmrtpipe/cluster_templates/lsf/start.tmpl
+++ b/pbsmrtpipe/cluster_templates/lsf/start.tmpl
@@ -1,1 +1,1 @@
-bsub -Is -J ${JOB_ID} -o ${STDOUT_FILE} -e ${STDERR_FILE} -n ${NPROC} -q interactive ${CMD}
+bsub -Is -J ${JOB_ID} -o ${STDOUT_FILE} -e ${STDERR_FILE} -n ${NPROC} -q interactive -R span[hosts=1] ${CMD}


### PR DESCRIPTION
#29747 - the change to current LSF templates is inspired by MSSM cluster.