### PR TITLE
Update pbtestkit-runner to output to console and log file. Update to 0.36.2.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -52,7 +52,7 @@ test-chunk-operators:
 
 test-sanity: test-contracts test-pipelines test-chunk-operators test-loader write-pipeline-templates
 
-test-suite: test-sanity test-unit test-dev
+test-suite: test-sanity test-unit test-dev write-pipeline-templates
 
 test-clean-suite: install test-suite
 

--- a/REQUIREMENTS.txt
+++ b/REQUIREMENTS.txt
@@ -1,7 +1,7 @@
 jinja2
 networkx
 pbcore >= 1.2.3
-pbcommand >= 0.3.7
+pbcommand >= 0.3.8
 pyparsing==1.5.7
 pydot
 jsonschema

--- a/pbsmrtpipe/__init__.py
+++ b/pbsmrtpipe/__init__.py
@@ -1,4 +1,4 @@
-VERSION = (0, 36, 1)
+VERSION = (0, 36, 2)
 
 
 def get_version():

--- a/pbsmrtpipe/cli.py
+++ b/pbsmrtpipe/cli.py
@@ -37,7 +37,8 @@ def _validate_preset_xml(path):
 
 
 def add_log_file_options(p):
-    p.add_argument('--log-file', type=str, help="Path to log file")
+    p.add_argument('--log-file', type=str, default=None, help="Path to log file")
+    p.add_argument('--log-file', type=str, default=None, help="Path to log file")
     return p
 
 LOG_LEVELS = ('DEBUG', 'INFO', 'WARNING', 'ERROR', 'CRITICAL')

--- a/pbsmrtpipe/core.py
+++ b/pbsmrtpipe/core.py
@@ -197,7 +197,9 @@ def load_pipeline_bindings(registered_pipeline_d, pipeline_id, display_name, ver
         else:
             raise MalformedPipelineError("Unhandled binding case '{o}' -> '{i}'".format(o=b_out, i=b_in))
 
-        log.info("registering pipeline {i}".format(i=pipeline.pipeline_id))
+        if pipeline.pipeline_id not in registered_pipeline_d:
+            log.debug("registering pipeline {i}".format(i=pipeline.pipeline_id))
+
         registered_pipeline_d[pipeline.pipeline_id] = pipeline
 
     return registered_pipeline_d


### PR DESCRIPTION
- output log file is always set to DEBUG
- --log-file is now configurable
- console level is configurable --log-level
- logging Handler to stderr is enabled
- update to pbcommand 0.3.8