### PR TITLE
Use Lambda as default genome size

### DIFF
--- a/pbsmrtpipe/registered_tool_contracts_sa3/pbfalcon.cli.gen_config_tool_contract.json
+++ b/pbsmrtpipe/registered_tool_contracts_sa3/pbfalcon.cli.gen_config_tool_contract.json
@@ -13,7 +13,7 @@
         "schema_options": [
             {
                 "pb_option": {
-                    "default": "5000000",
+                    "default": "8000",
                     "type": "string",
                     "option_id": "falcon_ns.task_options.HGAP_GenomeLength_str",
                     "name": "Genome length (base pairs) REQUIRED",
@@ -27,7 +27,7 @@
                 "type": "object",
                 "properties": {
                     "falcon_ns.task_options.HGAP_GenomeLength_str": {
-                        "default": "5000000",
+                        "default": "8000",
                         "type": "string",
                         "description": "Approx. number of base pairs expected in the genome. We choose other settings automatically, based on this. (To learn what we generate, see fc_*.cfg, currently called 'falcon_ns.tasks.task_falcon0_build_rdb-PacBio.FileTypes.txt' amongst output files.)",
                         "title": "Genome length (base pairs) REQUIRED"


### PR DESCRIPTION
It's probably good to let Lambda pass by default, since Lambda will probably be available everywhere. It's comforting for a user to be able to run *something* quickly.

No other default really makes sense.