### PR TITLE
Add DataSet filter task to resequencing pipeline

### DIFF
--- a/pbsmrtpipe/pb_pipelines/pb_pipelines_sa3.py
+++ b/pbsmrtpipe/pb_pipelines/pb_pipelines_sa3.py
@@ -215,7 +215,9 @@ def ds_fat_resequencing():
     additional reports
     """
 
-    return _core_gc_plus("pbsmrtpipe.pipelines.sa3_ds_resequencing:pbalign.tasks.pbalign:0", Constants.ENTRY_DS_REF)
+    filt = [(Constants.ENTRY_DS_SUBREAD, "pbcoretools.tasks.filterdataset:0")]
+    aln = _core_align_plus("pbcoretools.tasks.filterdataset:0", Constants.ENTRY_DS_REF)
+    return filt + aln + _core_gc_plus("pbalign.tasks.pbalign:0", Constants.ENTRY_DS_REF)
 
 
 def _core_mod_detection(alignment_ds, reference_ds):


### PR DESCRIPTION
I feel like there should be a better system for doing this. I don't want to
have to reconstruct each production pipeline to add this task, and yet many use
a pipeline output referencing trick that closes over the input I am trying to
modify.