### PR TITLE
add output file names and descriptions to datastore

### DIFF
--- a/REQUIREMENTS.txt
+++ b/REQUIREMENTS.txt
@@ -1,7 +1,7 @@
 jinja2
 networkx
 pbcore >= 1.2.6
-pbcommand >= 0.3.20
+pbcommand >= 0.3.22
 pyparsing==1.5.7
 pydot
 jsonschema

--- a/pbsmrtpipe/driver.py
+++ b/pbsmrtpipe/driver.py
@@ -332,11 +332,11 @@ def __exe_workflow(global_registry, ep_d, bg, task_opts, workflow_opts, output_d
             WS.add_datastore_file(total_ds_uri, datastore_file_, ignore_errors=True)
 
     def _update_analysis_reports_and_datastore(tnode_, task_):
-        for file_type_, path_ in zip(tnode_.meta_task.output_types, task_.output_files):
+        for file_type_, path_, name, description in zip(tnode_.meta_task.output_types, task_.output_files, tnode_.meta_task.output_file_display_names, tnode_.meta_task.output_file_descriptions):
             source_id = "{t}-{f}".format(t=task_.task_id, f=file_type_.file_type_id)
             ds_uuid = _get_dataset_uuid_or_create_uuid(path_)
             is_chunked_ = _is_chunked_task_node_type(tnode_)
-            ds_file_ = DataStoreFile(ds_uuid, source_id, file_type_.file_type_id, path_, is_chunked=is_chunked_)
+            ds_file_ = DataStoreFile(ds_uuid, source_id, file_type_.file_type_id, path_, is_chunked=is_chunked_, name=name, description=description)
             ds.add(ds_file_)
             ds.write_update_json(job_resources.datastore_json)
 

--- a/pbsmrtpipe/driver_utils.py
+++ b/pbsmrtpipe/driver_utils.py
@@ -347,8 +347,8 @@ def job_resource_create_and_setup_logs(job_root_dir, bg, task_opts, workflow_lev
 
     # Need to map entry points to a FileType and store in the DataStore? or
     # does DataStore only represent outputs?
-    smrtpipe_log_df = DataStoreFile(str(uuid.uuid4()), "pbsmrtpipe::pbsmrtpipe.log", FileTypes.LOG.file_type_id, pb_log_path)
-    master_log_df = DataStoreFile(str(uuid.uuid4()), "pbsmrtpipe::master.log", FileTypes.LOG.file_type_id, master_log_path)
+    smrtpipe_log_df = DataStoreFile(str(uuid.uuid4()), "pbsmrtpipe::pbsmrtpipe.log", FileTypes.LOG.file_type_id, pb_log_path, name="pbsmrtpipe log")
+    master_log_df = DataStoreFile(str(uuid.uuid4()), "pbsmrtpipe::master.log", FileTypes.LOG.file_type_id, master_log_path, name="Master log file")
     ds = write_and_initialize_data_store_json(job_resources.datastore_json, [smrtpipe_log_df, master_log_df])
     slog.info("successfully initialized datastore.")
 

--- a/pbsmrtpipe/models.py
+++ b/pbsmrtpipe/models.py
@@ -204,7 +204,9 @@ class MetaTask(object):
                  output_file_names,
                  mutable_files,
                  description,
-                 display_name, version=None):
+                 display_name, version=None,
+                 output_file_display_names=None,
+                 output_file_descriptions=None):
         """These may be specified as the DI version"""
         self.task_id = task_id
         self.input_types = input_types
@@ -219,6 +221,10 @@ class MetaTask(object):
         self.description = description
         self.display_name = display_name
         self.version = version if version is not None else "UNKNOWN"
+        self.output_file_display_names = output_file_display_names if \
+            output_file_display_names is not None else ["" for x in output_file_names]
+        self.output_file_descriptions = output_file_descriptions if \
+            output_file_descriptions is not None else ["" for x in output_file_names]
 
     def __eq__(self, other):
         # need to rethink this.
@@ -811,7 +817,7 @@ class _ToolContractAble(object):
 class ToolContractMetaTask(MetaTask, _ToolContractAble):
 
     def __init__(self, tool_contract, task_id, is_distributed, input_types, output_types, options_schema,
-                 nproc, resource_types, output_file_names, mutable_files, description, display_name, version="NA"):
+                 nproc, resource_types, output_file_names, mutable_files, description, display_name, version="NA", output_file_display_names=None, output_file_descriptions=None):
         """
         :type tool_contract: pbcommand.models.ToolContract
 
@@ -819,7 +825,7 @@ class ToolContractMetaTask(MetaTask, _ToolContractAble):
         # this is naughty and terrible. to_cmd should not be here!!!
         to_cmd_func = None
         super(ToolContractMetaTask, self).__init__(task_id, is_distributed, input_types, output_types, options_schema,
-                                                   nproc, resource_types, to_cmd_func, output_file_names, mutable_files, description, display_name, version=version)
+                                                   nproc, resource_types, to_cmd_func, output_file_names, mutable_files, description, display_name, version=version, output_file_display_names=output_file_display_names, output_file_descriptions=output_file_descriptions)
         # Adding in a bit of duplication here. Once everything uses TC, then
         # then the entire system can dramatically be simplify
         self.tool_contract = tool_contract

--- a/pbsmrtpipe/pb_io.py
+++ b/pbsmrtpipe/pb_io.py
@@ -1010,6 +1010,8 @@ def parse_operator_xml(f):
 def _to_meta_task(tc, task_type, input_types, output_types, schema_option_d,
         output_file_names):
     mutable_files = []
+    display_names = [oft.display_name for oft in tc.task.output_file_types]
+    descriptions = [oft.description for oft in tc.task.output_file_types]
     return ToolContractMetaTask(tc,
                                 tc.task.task_id,
                                 task_type,
@@ -1022,7 +1024,9 @@ def _to_meta_task(tc, task_type, input_types, output_types, schema_option_d,
                                 mutable_files,
                                 tc.task.description,
                                 tc.task.name,
-                                version=tc.task.version)
+                                version=tc.task.version,
+                                output_file_display_names=display_names,
+                                output_file_descriptions=descriptions)
 
 
 def _to_meta_scatter_task(tc, task_type, input_types, output_types,


### PR DESCRIPTION
This only works for generic tasks, not gather tasks.  I'll take care of those in a second pass - they're a little tricky because we want to use the names and descriptions for the chunked task and not the gather task.