### PR TITLE
add output file names and descriptions to datastore

### DIFF
--- a/REQUIREMENTS.txt
+++ b/REQUIREMENTS.txt
@@ -1,7 +1,7 @@
 jinja2
 networkx
 pbcore >= 1.2.6
-pbcommand >= 0.3.20
+pbcommand >= 0.3.22
 pyparsing==1.5.7
 pydot
 jsonschema

--- a/pbsmrtpipe/driver.py
+++ b/pbsmrtpipe/driver.py
@@ -332,11 +332,11 @@ def __exe_workflow(global_registry, ep_d, bg, task_opts, workflow_opts, output_d
             WS.add_datastore_file(total_ds_uri, datastore_file_, ignore_errors=True)
 
     def _update_analysis_reports_and_datastore(tnode_, task_):
-        for file_type_, path_ in zip(tnode_.meta_task.output_types, task_.output_files):
+        for file_type_, path_, name, description in zip(tnode_.meta_task.output_types, task_.output_files, tnode_.meta_task.output_file_display_names, tnode_.meta_task.output_file_descriptions):
             source_id = "{t}-{f}".format(t=task_.task_id, f=file_type_.file_type_id)
             ds_uuid = _get_dataset_uuid_or_create_uuid(path_)
             is_chunked_ = _is_chunked_task_node_type(tnode_)
-            ds_file_ = DataStoreFile(ds_uuid, source_id, file_type_.file_type_id, path_, is_chunked=is_chunked_)
+            ds_file_ = DataStoreFile(ds_uuid, source_id, file_type_.file_type_id, path_, is_chunked=is_chunked_, name=name, description=description)
             ds.add(ds_file_)
             ds.write_update_json(job_resources.datastore_json)
 

--- a/pbsmrtpipe/driver.py
+++ b/pbsmrtpipe/driver.py
@@ -332,6 +332,9 @@ def __exe_workflow(global_registry, ep_d, bg, task_opts, workflow_opts, output_d
             WS.add_datastore_file(total_ds_uri, datastore_file_, ignore_errors=True)
 
     def _update_analysis_reports_and_datastore(tnode_, task_):
+        assert (len(tnode_.meta_task.output_file_display_names) ==
+                len(tnode_.meta_task.output_file_descriptions) ==
+                len(tnode_.meta_task.output_types) == len(task_.output_files))
         for file_type_, path_, name, description in zip(tnode_.meta_task.output_types, task_.output_files, tnode_.meta_task.output_file_display_names, tnode_.meta_task.output_file_descriptions):
             source_id = "{t}-{f}".format(t=task_.task_id, f=file_type_.file_type_id)
             ds_uuid = _get_dataset_uuid_or_create_uuid(path_)

--- a/pbsmrtpipe/driver_utils.py
+++ b/pbsmrtpipe/driver_utils.py
@@ -347,8 +347,8 @@ def job_resource_create_and_setup_logs(job_root_dir, bg, task_opts, workflow_lev
 
     # Need to map entry points to a FileType and store in the DataStore? or
     # does DataStore only represent outputs?
-    smrtpipe_log_df = DataStoreFile(str(uuid.uuid4()), "pbsmrtpipe::pbsmrtpipe.log", FileTypes.LOG.file_type_id, pb_log_path, name="pbsmrtpipe log")
-    master_log_df = DataStoreFile(str(uuid.uuid4()), "pbsmrtpipe::master.log", FileTypes.LOG.file_type_id, master_log_path, name="Master log file")
+    smrtpipe_log_df = DataStoreFile(str(uuid.uuid4()), "pbsmrtpipe::pbsmrtpipe.log", FileTypes.LOG.file_type_id, pb_log_path, name="pbsmrtpipe log", description="pbsmrtpipe log")
+    master_log_df = DataStoreFile(str(uuid.uuid4()), "pbsmrtpipe::master.log", FileTypes.LOG.file_type_id, master_log_path, name="Master log file", description="Master log")
     ds = write_and_initialize_data_store_json(job_resources.datastore_json, [smrtpipe_log_df, master_log_df])
     slog.info("successfully initialized datastore.")
 

--- a/pbsmrtpipe/driver_utils.py
+++ b/pbsmrtpipe/driver_utils.py
@@ -347,8 +347,8 @@ def job_resource_create_and_setup_logs(job_root_dir, bg, task_opts, workflow_lev
 
     # Need to map entry points to a FileType and store in the DataStore? or
     # does DataStore only represent outputs?
-    smrtpipe_log_df = DataStoreFile(str(uuid.uuid4()), "pbsmrtpipe::pbsmrtpipe.log", FileTypes.LOG.file_type_id, pb_log_path)
-    master_log_df = DataStoreFile(str(uuid.uuid4()), "pbsmrtpipe::master.log", FileTypes.LOG.file_type_id, master_log_path)
+    smrtpipe_log_df = DataStoreFile(str(uuid.uuid4()), "pbsmrtpipe::pbsmrtpipe.log", FileTypes.LOG.file_type_id, pb_log_path, name="pbsmrtpipe log")
+    master_log_df = DataStoreFile(str(uuid.uuid4()), "pbsmrtpipe::master.log", FileTypes.LOG.file_type_id, master_log_path, name="Master log file")
     ds = write_and_initialize_data_store_json(job_resources.datastore_json, [smrtpipe_log_df, master_log_df])
     slog.info("successfully initialized datastore.")
 

--- a/pbsmrtpipe/models.py
+++ b/pbsmrtpipe/models.py
@@ -204,7 +204,9 @@ class MetaTask(object):
                  output_file_names,
                  mutable_files,
                  description,
-                 display_name, version=None):
+                 display_name, version=None,
+                 output_file_display_names=None,
+                 output_file_descriptions=None):
         """These may be specified as the DI version"""
         self.task_id = task_id
         self.input_types = input_types
@@ -219,6 +221,10 @@ class MetaTask(object):
         self.description = description
         self.display_name = display_name
         self.version = version if version is not None else "UNKNOWN"
+        self.output_file_display_names = output_file_display_names if \
+            output_file_display_names is not None else ["" for x in output_file_names]
+        self.output_file_descriptions = output_file_descriptions if \
+            output_file_descriptions is not None else ["" for x in output_file_names]
 
     def __eq__(self, other):
         # need to rethink this.
@@ -811,7 +817,7 @@ class _ToolContractAble(object):
 class ToolContractMetaTask(MetaTask, _ToolContractAble):
 
     def __init__(self, tool_contract, task_id, is_distributed, input_types, output_types, options_schema,
-                 nproc, resource_types, output_file_names, mutable_files, description, display_name, version="NA"):
+                 nproc, resource_types, output_file_names, mutable_files, description, display_name, version="NA", output_file_display_names=None, output_file_descriptions=None):
         """
         :type tool_contract: pbcommand.models.ToolContract
 
@@ -819,7 +825,7 @@ class ToolContractMetaTask(MetaTask, _ToolContractAble):
         # this is naughty and terrible. to_cmd should not be here!!!
         to_cmd_func = None
         super(ToolContractMetaTask, self).__init__(task_id, is_distributed, input_types, output_types, options_schema,
-                                                   nproc, resource_types, to_cmd_func, output_file_names, mutable_files, description, display_name, version=version)
+                                                   nproc, resource_types, to_cmd_func, output_file_names, mutable_files, description, display_name, version=version, output_file_display_names=output_file_display_names, output_file_descriptions=output_file_descriptions)
         # Adding in a bit of duplication here. Once everything uses TC, then
         # then the entire system can dramatically be simplify
         self.tool_contract = tool_contract

--- a/pbsmrtpipe/models.py
+++ b/pbsmrtpipe/models.py
@@ -351,14 +351,17 @@ class MetaScatterTask(MetaTask):
     def __init__(self, task_id, is_distributed, input_types, output_types,
                  opt_schema, nproc, resource_types, cmd_func, chunk_di,
                  chunk_keys, output_file_names, mutable_files, description,
-                 display_name, version=None):
+                 display_name, version=None,
+                 output_file_display_names=None,
+                 output_file_descriptions=None):
         super(MetaScatterTask, self).__init__(task_id, is_distributed,
                                               input_types, output_types,
                                               opt_schema, nproc,
                                               resource_types, cmd_func,
                                               output_file_names, mutable_files,
                                               description, display_name,
-                                              version=version)
+                                              version=version,
+                                              output_file_display_names=output_file_display_names, output_file_descriptions=output_file_descriptions)
         # this can be a primitive value or a DI model list
         self.chunk_di = chunk_di
         self.chunk_keys = chunk_keys
@@ -371,13 +374,15 @@ class MetaGatherTask(MetaTask):
     def __init__(self, task_id, is_distributed, input_types, output_types,
                  opt_schema, nproc, resource_types, cmd_func,
                  output_file_names, mutable_files, description, display_name,
-                 version=None):
+                 version=None, output_file_display_names=None,
+                 output_file_descriptions=None):
         super(MetaGatherTask, self).__init__(task_id, is_distributed,
                                              input_types, output_types,
                                              opt_schema, nproc, resource_types,
                                              cmd_func, output_file_names,
                                              mutable_files, description,
-                                             display_name, version=version)
+                                             display_name, version=version,
+                                             output_file_display_names=output_file_display_names, output_file_descriptions=output_file_descriptions)
 
 
 class Task(object):
@@ -847,27 +852,30 @@ class ToolContractMetaTask(MetaTask, _ToolContractAble):
 class ScatterToolContractMetaTask(MetaScatterTask, _ToolContractAble):
 
     def __init__(self, tool_contract, task_id, is_distributed, input_types, output_types, options_schema,
-                 nproc, resource_types, output_file_names, mutable_files, description, display_name, max_nchunks, chunk_keys, version="NA"):
+                 nproc, resource_types, output_file_names, mutable_files, description, display_name, max_nchunks, chunk_keys, version="NA", output_file_display_names=None, output_file_descriptions=None):
         """
         :type tool_contract: pbcommand.models.ToolContract
 
         """
         to_cmd_func = None
-        super(ScatterToolContractMetaTask, self).__init__(task_id,
-                                                          is_distributed,
-                                                          input_types,
-                                                          output_types,
-                                                          options_schema,
-                                                          nproc,
-                                                          resource_types,
-                                                          to_cmd_func,
-                                                          max_nchunks,
-                                                          chunk_keys,
-                                                          output_file_names,
-                                                          mutable_files,
-                                                          description,
-                                                          display_name,
-                                                          version=version)
+        super(ScatterToolContractMetaTask, self).__init__(
+            task_id,
+            is_distributed,
+            input_types,
+            output_types,
+            options_schema,
+            nproc,
+            resource_types,
+            to_cmd_func,
+            max_nchunks,
+            chunk_keys,
+            output_file_names,
+            mutable_files,
+            description,
+            display_name,
+            version=version,
+            output_file_display_names=output_file_display_names,
+            output_file_descriptions=output_file_descriptions)
         self.tool_contract = tool_contract
 
     @property
@@ -888,7 +896,8 @@ class GatherToolContractMetaTask(MetaGatherTask, _ToolContractAble):
     def __init__(self, tool_contract, task_id, is_distributed, input_types,
                  output_types, options_schema,
                  nproc, resource_types, output_file_names, mutable_files,
-                 description, display_name, version="NA"):
+                 description, display_name, version="NA",
+                 output_file_display_names=None, output_file_descriptions=None):
         """
 
         :type driver: ToolDriver
@@ -896,18 +905,21 @@ class GatherToolContractMetaTask(MetaGatherTask, _ToolContractAble):
 
         """
         _to_cmd_func = None
-        super(GatherToolContractMetaTask, self).__init__(task_id,
-                                                         is_distributed,
-                                                         input_types,
-                                                         output_types,
-                                                         options_schema, nproc,
-                                                         resource_types,
-                                                         _to_cmd_func,
-                                                         output_file_names,
-                                                         mutable_files,
-                                                         description,
-                                                         display_name,
-                                                         version=version)
+        super(GatherToolContractMetaTask, self).__init__(
+            task_id,
+            is_distributed,
+            input_types,
+            output_types,
+            options_schema, nproc,
+            resource_types,
+            _to_cmd_func,
+            output_file_names,
+            mutable_files,
+            description,
+            display_name,
+            version=version,
+            output_file_display_names=output_file_display_names,
+            output_file_descriptions=output_file_descriptions)
         self.tool_contract = tool_contract
         # self.chunk_key = chunk_key
 

--- a/pbsmrtpipe/pb_io.py
+++ b/pbsmrtpipe/pb_io.py
@@ -1010,6 +1010,8 @@ def parse_operator_xml(f):
 def _to_meta_task(tc, task_type, input_types, output_types, schema_option_d,
         output_file_names):
     mutable_files = []
+    display_names = [oft.display_name for oft in tc.task.output_file_types]
+    descriptions = [oft.description for oft in tc.task.output_file_types]
     return ToolContractMetaTask(tc,
                                 tc.task.task_id,
                                 task_type,
@@ -1022,7 +1024,9 @@ def _to_meta_task(tc, task_type, input_types, output_types, schema_option_d,
                                 mutable_files,
                                 tc.task.description,
                                 tc.task.name,
-                                version=tc.task.version)
+                                version=tc.task.version,
+                                output_file_display_names=display_names,
+                                output_file_descriptions=descriptions)
 
 
 def _to_meta_scatter_task(tc, task_type, input_types, output_types,

--- a/pbsmrtpipe/pb_io.py
+++ b/pbsmrtpipe/pb_io.py
@@ -1031,6 +1031,8 @@ def _to_meta_task(tc, task_type, input_types, output_types, schema_option_d,
 
 def _to_meta_scatter_task(tc, task_type, input_types, output_types,
                           schema_option_d, max_nchunks, chunk_keys):
+    display_names = [oft.display_name for oft in tc.task.output_file_types]
+    descriptions = [oft.description for oft in tc.task.output_file_types]
     output_file_names = []
     mutable_files = []
     return ScatterToolContractMetaTask(tc,
@@ -1046,10 +1048,14 @@ def _to_meta_scatter_task(tc, task_type, input_types, output_types,
                                        tc.task.description,
                                        tc.task.name,
                                        max_nchunks, chunk_keys,
-                                       version=tc.task.version)
+                                       version=tc.task.version,
+                                       output_file_display_names=display_names,
+                                       output_file_descriptions=descriptions)
 
 
 def _to_meta_gather_task(tc, task_type, input_types, output_types, schema_option_d):
+    display_names = [oft.display_name for oft in tc.task.output_file_types]
+    descriptions = [oft.description for oft in tc.task.output_file_types]
     output_file_names = []
     mutable_files = []
     return GatherToolContractMetaTask(tc,
@@ -1064,7 +1070,9 @@ def _to_meta_gather_task(tc, task_type, input_types, output_types, schema_option
                                       mutable_files,
                                       tc.task.description,
                                       tc.task.name,
-                                      version=tc.task.version)
+                                      version=tc.task.version,
+                                      output_file_display_names=display_names,
+                                      output_file_descriptions=descriptions)
 
 
 def tool_contract_to_meta_task(tc, max_nchunks):

--- a/pbsmrtpipe/testkit/core/test_resolved_tool_contracts.py
+++ b/pbsmrtpipe/testkit/core/test_resolved_tool_contracts.py
@@ -9,6 +9,7 @@ import logging
 
 from pbcommand.pb_io.tool_contract_io import (load_tool_contract_from,
     load_resolved_tool_contract_from)
+from pbsmrtpipe.testkit.loader import dtype_and_uuid_from_dataset_xml
 from .base import TestBase
 
 log = logging.getLogger(__name__)
@@ -36,3 +37,26 @@ class TestResolvedToolContracts(TestBase):
             else:
                 self.assertFalse(rtc.task.is_distributed,
                     "Resolved tool contract {f} has unexpected is_distributed=True".format(f=rtc_file))
+
+
+    def test_rtc_output_files_in_datastore(self):
+        """
+        Confirm that all output files listed in resolved tool contracts are
+        represented in the datastore.
+        """
+        datastore = None
+        p = os.path.join(self.job_dir, "workflow", "datastore.json")
+        with open(p, 'r') as r:
+            datastore = json.loads(r.read())
+        tasks_dir = os.path.join(self.job_dir, "tasks")
+        datastore_output_files = {f["path"] for f in datastore["files"]}
+        datastore_uuids = {f["uniqueId"] for f in datastore["files"]}
+        for task_dir in os.listdir(tasks_dir):
+            if task_dir.startswith("."):
+                continue
+            rtc_file = os.path.join(tasks_dir, task_dir,
+                "resolved-tool-contract.json")
+            rtc = load_resolved_tool_contract_from(rtc_file)
+            for ofn in rtc.task.output_files:
+                self.assertTrue(ofn in datastore_output_files,
+                                "{o} not found in datastore".format(o=ofn))

--- a/pbsmrtpipe/testkit/loader.py
+++ b/pbsmrtpipe/testkit/loader.py
@@ -1,4 +1,6 @@
 """Dynamically load test cases from a cfg file"""
+
+import xml.etree.ElementTree as ET
 import importlib
 import logging
 import ConfigParser
@@ -90,3 +92,11 @@ def parse_cfg_file(path):
                         test_cases.append(x)
 
     return test_cases
+
+
+def dtype_and_uuid_from_dataset_xml(dataset_xml):
+    tree = ET.parse(dataset_xml)
+    root = tree.getroot()
+    metatype = root.attrib['MetaType']
+    unique_id = root.attrib['UniqueId']
+    return metatype, unique_id

--- a/pbsmrtpipe/testkit/service_runner.py
+++ b/pbsmrtpipe/testkit/service_runner.py
@@ -18,7 +18,8 @@ import pbcommand.services
 
 from pbsmrtpipe.pb_io import parse_pipeline_preset_xml
 from pbsmrtpipe.testkit.butler import config_parser_to_butler
-from pbsmrtpipe.testkit.loader import parse_cfg_file
+from pbsmrtpipe.testkit.loader import (parse_cfg_file,
+    dtype_and_uuid_from_dataset_xml)
 from pbsmrtpipe.testkit.runner import run_butler_tests
 
 log = logging.getLogger(__name__)
@@ -29,14 +30,6 @@ def get_entrypoints(testkit_cfg):
     parsed_cfg = config_parser_to_butler(testkit_cfg)
     entrypoints = parsed_cfg.entry_points
     return entrypoints
-
-
-def dtype_and_uuid_from_dataset_xml(dataset_xml):
-    tree = ET.parse(dataset_xml)
-    root = tree.getroot()
-    metatype = root.attrib['MetaType']
-    unique_id = root.attrib['UniqueId']
-    return metatype, unique_id
 
 
 def get_task_and_workflow_options(testkit_cfg):


### PR DESCRIPTION
This should actually work with real pipelines, although it still isn't substituting the name/description for chunked task output files in the corresponding gather task.