### PR TITLE
Added sa3_ds_isoseq_with_genome pipeline

### DIFF
--- a/pbsmrtpipe/chunk_operators/operator_chunk_isoseq_map_isoforms_to_genome.xml
+++ b/pbsmrtpipe/chunk_operators/operator_chunk_isoseq_map_isoforms_to_genome.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<chunk-operator id="pbsmrtpipe.operators.chunk_pbtranscript_map_isoforms_to_genome">
+
+    <task-id>pbtranscript.tasks.map_isoforms_to_genome</task-id>
+
+    <scatter>
+        <scatter-task-id>pbtranscript.tasks.scatter_map_isoforms_to_genome</scatter-task-id>
+        <chunks>
+            <chunk out="$chunk.fastq_id" in="pbtranscript.tasks.map_isoforms_to_genome:0"/>
+            <chunk out="$chunk.gmap_ref_id" in="pbtranscript.tasks.map_isoforms_to_genome:1"/>
+        </chunks>
+    </scatter>
+    <!-- Define the Gather Mechanism -->
+    <gather>
+        <chunks>
+            <chunk>
+                <gather-task-id>pbtranscript.tasks.gather_gmap_sam</gather-task-id>
+                <chunk-key>$chunk.sam_id</chunk-key>
+                <task-output>pbtranscript.tasks.map_isoforms_to_genome:0</task-output>
+            </chunk>
+        </chunks>
+    </gather>
+</chunk-operator>

--- a/pbsmrtpipe/registered_tool_contracts_sa3/pbtranscript.tasks.combine_cluster_bins_tool_contract.json
+++ b/pbsmrtpipe/registered_tool_contracts_sa3/pbtranscript.tasks.combine_cluster_bins_tool_contract.json
@@ -1,180 +1,187 @@
 {
-    "version": "1.0.0.177015", 
+    "version": "1.0.0.177900",
     "driver": {
-        "serialization": "json", 
-        "exe": "python -m pbtranscript.tasks.combine_cluster_bins --resolved-tool-contract ", 
+        "serialization": "json",
+        "exe": "python -m pbtranscript.tasks.combine_cluster_bins --resolved-tool-contract ",
         "env": {}
-    }, 
-    "tool_contract_id": "pbtranscript.tasks.combine_cluster_bins", 
+    },
+    "tool_contract_id": "pbtranscript.tasks.combine_cluster_bins",
     "tool_contract": {
-        "task_type": "pbsmrtpipe.task_types.standard", 
+        "task_type": "pbsmrtpipe.task_types.standard",
         "resource_types": [
             "$tmpdir"
-        ], 
-        "description": "Constants used TOOL_ID", 
+        ],
+        "description": "Constants used TOOL_ID",
         "schema_options": [
             {
                 "pb_option": {
-                    "default": 0.99, 
-                    "type": "number", 
-                    "option_id": "pbtranscript.task_options.hq_quiver_min_accuracy", 
-                    "name": "Minimum Quiver Accuracy", 
+                    "default": 0.99,
+                    "type": "number",
+                    "option_id": "pbtranscript.task_options.hq_quiver_min_accuracy",
+                    "name": "Minimum Quiver Accuracy",
                     "description": "Minimum allowed quiver accuracy to classify an isoform as hiqh-quality."
-                }, 
-                "title": "JSON Schema for pbtranscript.task_options.hq_quiver_min_accuracy", 
+                },
+                "title": "JSON Schema for pbtranscript.task_options.hq_quiver_min_accuracy",
                 "required": [
                     "pbtranscript.task_options.hq_quiver_min_accuracy"
-                ], 
-                "$schema": "http://json-schema.org/draft-04/schema#", 
-                "type": "object", 
+                ],
+                "$schema": "http://json-schema.org/draft-04/schema#",
+                "type": "object",
                 "properties": {
                     "pbtranscript.task_options.hq_quiver_min_accuracy": {
-                        "default": 0.99, 
-                        "type": "number", 
-                        "description": "Minimum allowed quiver accuracy to classify an isoform as hiqh-quality.", 
+                        "default": 0.99,
+                        "type": "number",
+                        "description": "Minimum allowed quiver accuracy to classify an isoform as hiqh-quality.",
                         "title": "Minimum Quiver Accuracy"
                     }
                 }
-            }, 
+            },
             {
                 "pb_option": {
-                    "default": 100, 
-                    "type": "integer", 
-                    "option_id": "pbtranscript.task_options.qv_trim_5p", 
-                    "name": "Trim QVs 5'", 
+                    "default": 100,
+                    "type": "integer",
+                    "option_id": "pbtranscript.task_options.qv_trim_5p",
+                    "name": "Trim QVs 5'",
                     "description": "Ignore QV of n bases in the 5' end."
-                }, 
-                "title": "JSON Schema for pbtranscript.task_options.qv_trim_5p", 
+                },
+                "title": "JSON Schema for pbtranscript.task_options.qv_trim_5p",
                 "required": [
                     "pbtranscript.task_options.qv_trim_5p"
-                ], 
-                "$schema": "http://json-schema.org/draft-04/schema#", 
-                "type": "object", 
+                ],
+                "$schema": "http://json-schema.org/draft-04/schema#",
+                "type": "object",
                 "properties": {
                     "pbtranscript.task_options.qv_trim_5p": {
-                        "default": 100, 
-                        "type": "integer", 
-                        "description": "Ignore QV of n bases in the 5' end.", 
+                        "default": 100,
+                        "type": "integer",
+                        "description": "Ignore QV of n bases in the 5' end.",
                         "title": "Trim QVs 5'"
                     }
                 }
-            }, 
+            },
             {
                 "pb_option": {
-                    "default": 30, 
-                    "type": "integer", 
-                    "option_id": "pbtranscript.task_options.qv_trim_3p", 
-                    "name": "Trim QVs 3'", 
+                    "default": 30,
+                    "type": "integer",
+                    "option_id": "pbtranscript.task_options.qv_trim_3p",
+                    "name": "Trim QVs 3'",
                     "description": "Ignore QV of n bases in the 3' end."
-                }, 
-                "title": "JSON Schema for pbtranscript.task_options.qv_trim_3p", 
+                },
+                "title": "JSON Schema for pbtranscript.task_options.qv_trim_3p",
                 "required": [
                     "pbtranscript.task_options.qv_trim_3p"
-                ], 
-                "$schema": "http://json-schema.org/draft-04/schema#", 
-                "type": "object", 
+                ],
+                "$schema": "http://json-schema.org/draft-04/schema#",
+                "type": "object",
                 "properties": {
                     "pbtranscript.task_options.qv_trim_3p": {
-                        "default": 30, 
-                        "type": "integer", 
-                        "description": "Ignore QV of n bases in the 3' end.", 
+                        "default": 30,
+                        "type": "integer",
+                        "description": "Ignore QV of n bases in the 3' end.",
                         "title": "Trim QVs 3'"
                     }
                 }
-            }, 
+            },
             {
                 "pb_option": {
-                    "default": "", 
-                    "type": "string", 
-                    "option_id": "pbtranscript.task_options.sample_name", 
-                    "name": "sample Name", 
+                    "default": "",
+                    "type": "string",
+                    "option_id": "pbtranscript.task_options.sample_name",
+                    "name": "sample Name",
                     "description": "Sample Name"
-                }, 
-                "title": "JSON Schema for pbtranscript.task_options.sample_name", 
+                },
+                "title": "JSON Schema for pbtranscript.task_options.sample_name",
                 "required": [
                     "pbtranscript.task_options.sample_name"
-                ], 
-                "$schema": "http://json-schema.org/draft-04/schema#", 
-                "type": "object", 
+                ],
+                "$schema": "http://json-schema.org/draft-04/schema#",
+                "type": "object",
                 "properties": {
                     "pbtranscript.task_options.sample_name": {
-                        "default": "", 
-                        "type": "string", 
-                        "description": "Sample Name", 
+                        "default": "",
+                        "type": "string",
+                        "description": "Sample Name",
                         "title": "sample Name"
                     }
                 }
             }
-        ], 
+        ],
         "output_types": [
             {
-                "title": "PacBio ContigSet file", 
-                "description": "Output unpolished consensus isoforms", 
-                "default_name": "consensus_isoforms", 
-                "id": "consensus_isoforms", 
+                "title": "PacBio ContigSet file",
+                "description": "Output unpolished consensus isoforms",
+                "default_name": "consensus_isoforms",
+                "id": "consensus_isoforms",
                 "file_type_id": "PacBio.DataSet.ContigSet"
-            }, 
+            },
             {
-                "title": "JSON summary", 
-                "description": "JSON summary", 
-                "default_name": "summary", 
-                "id": "json_summary", 
+                "title": "JSON summary",
+                "description": "JSON summary",
+                "default_name": "summary",
+                "id": "json_summary",
                 "file_type_id": "PacBio.FileTypes.json"
-            }, 
+            },
             {
-                "title": "CSV file", 
-                "description": "TXT file to output cluster summary (default: *.cluster_summary.txt)", 
-                "default_name": "cluster_report", 
-                "id": "cluster_report", 
+                "title": "CSV file",
+                "description": "TXT file to output cluster summary (default: *.cluster_summary.txt)",
+                "default_name": "cluster_report",
+                "id": "cluster_report",
                 "file_type_id": "PacBio.FileTypes.csv"
-            }, 
+            },
             {
-                "title": "ContigSet", 
-                "description": "High-quality isoform sequences", 
-                "default_name": "hq_isoforms", 
-                "id": "hq_isoforms_fa", 
+                "title": "ContigSet",
+                "description": "High-quality isoform sequences",
+                "default_name": "hq_isoforms",
+                "id": "hq_isoforms_fa",
                 "file_type_id": "PacBio.DataSet.ContigSet"
-            }, 
+            },
             {
-                "title": "FASTQ", 
-                "description": "High-quality isoform sequences with quality scores", 
-                "default_name": "hq_isoforms", 
-                "id": "hq_isoforms_fq", 
+                "title": "FASTQ",
+                "description": "High-quality isoform sequences with quality scores",
+                "default_name": "hq_isoforms",
+                "id": "hq_isoforms_fq",
                 "file_type_id": "PacBio.FileTypes.Fastq"
-            }, 
+            },
             {
-                "title": "ContigSet", 
-                "description": "Low-quality isoform sequences", 
-                "default_name": "lq_isoforms", 
-                "id": "lq_isoforms_fa", 
+                "title": "ContigSet",
+                "description": "Low-quality isoform sequences",
+                "default_name": "lq_isoforms",
+                "id": "lq_isoforms_fa",
                 "file_type_id": "PacBio.DataSet.ContigSet"
-            }, 
+            },
             {
-                "title": "FASTQ", 
-                "description": "Low-quality isoform sequences with quality scores", 
-                "default_name": "lq_isoforms", 
-                "id": "lq_isoforms_fq", 
+                "title": "FASTQ",
+                "description": "Low-quality isoform sequences with quality scores",
+                "default_name": "lq_isoforms",
+                "id": "lq_isoforms_fq",
                 "file_type_id": "PacBio.FileTypes.Fastq"
+            },
+            {
+                "title": "Pickle",
+                "description": "Pickle mapping HQ (LQ) sample prefixes with ICE dir",
+                "default_name": "hq_lq_prefix_dict",
+                "id": "hq_lq_prefix_dict",
+                "file_type_id": "PacBio.FileTypes.pickle"
             }
-        ], 
-        "_comment": "Created by v0.3.25", 
-        "name": "pbtranscript.tasks.combine_cluster_bins", 
+        ],
+        "_comment": "Created by v0.3.30",
+        "name": "pbtranscript.tasks.combine_cluster_bins",
         "input_types": [
             {
-                "description": "Cluster chunks pickle file", 
-                "title": "Pickle In", 
-                "id": "cluster_chunks_pickle", 
+                "description": "Cluster chunks pickle file",
+                "title": "Pickle In",
+                "id": "cluster_chunks_pickle",
                 "file_type_id": "PacBio.FileTypes.pickle"
-            }, 
+            },
             {
-                "description": "Setinel file", 
-                "title": "Sentinel In", 
-                "id": "cluster_sentinel_in", 
+                "description": "Setinel file",
+                "title": "Sentinel In",
+                "id": "cluster_sentinel_in",
                 "file_type_id": "PacBio.FileTypes.txt"
             }
-        ], 
-        "nproc": "$max_nproc", 
-        "is_distributed": true, 
+        ],
+        "nproc": "$max_nproc",
+        "is_distributed": true,
         "tool_contract_id": "pbtranscript.tasks.combine_cluster_bins"
     }
 }

--- a/pbsmrtpipe/registered_tool_contracts_sa3/pbtranscript.tasks.gather_gmap_sam_tool_contract.json
+++ b/pbsmrtpipe/registered_tool_contracts_sa3/pbtranscript.tasks.gather_gmap_sam_tool_contract.json
@@ -1,0 +1,37 @@
+{
+    "version": "1.0.0.177900",
+    "driver": {
+        "serialization": "json",
+        "exe": "python -m pbtranscript.tasks.gather_gmap_sam --resolved-tool-contract ",
+        "env": {}
+    },
+    "tool_contract_id": "pbtranscript.tasks.gather_gmap_sam",
+    "tool_contract": {
+        "task_type": "pbsmrtpipe.task_types.gathered",
+        "resource_types": [],
+        "description": "Chunk Gather for GMAP SAM",
+        "schema_options": [],
+        "output_types": [
+            {
+                "title": "SAM",
+                "description": "Gathered SAM",
+                "default_name": "Gathered SAM",
+                "id": "sam_out",
+                "file_type_id": "PacBio.FileTypes.sam"
+            }
+        ],
+        "_comment": "Created by v0.3.30",
+        "name": "Gather GMAP SAM",
+        "input_types": [
+            {
+                "description": "Gathered CHUNK Json with chunk key",
+                "title": "Gather CHUNK Json",
+                "id": "cjson_in",
+                "file_type_id": "PacBio.FileTypes.CHUNK"
+            }
+        ],
+        "nproc": 1,
+        "is_distributed": true,
+        "tool_contract_id": "pbtranscript.tasks.gather_gmap_sam"
+    }
+}

--- a/pbsmrtpipe/registered_tool_contracts_sa3/pbtranscript.tasks.map_isoforms_to_genome_tool_contract.json
+++ b/pbsmrtpipe/registered_tool_contracts_sa3/pbtranscript.tasks.map_isoforms_to_genome_tool_contract.json
@@ -1,0 +1,69 @@
+{
+    "version": "1.0.0.177900",
+    "driver": {
+        "serialization": "json",
+        "exe": "python -m pbtranscript.tasks.map_isoforms_to_genome --resolved-tool-contract ",
+        "env": {}
+    },
+    "tool_contract_id": "pbtranscript.tasks.map_isoforms_to_genome",
+    "tool_contract": {
+        "task_type": "pbsmrtpipe.task_types.standard",
+        "resource_types": [
+            "$tmpdir"
+        ],
+        "description": "Constants used in tool contract.",
+        "schema_options": [
+            {
+                "pb_option": {
+                    "default": 24,
+                    "type": "integer",
+                    "option_id": "pbtranscript.task_options.gmap_nproc",
+                    "name": "GMAP nproc",
+                    "description": "GMAP nproc"
+                },
+                "title": "JSON Schema for pbtranscript.task_options.gmap_nproc",
+                "required": [
+                    "pbtranscript.task_options.gmap_nproc"
+                ],
+                "$schema": "http://json-schema.org/draft-04/schema#",
+                "type": "object",
+                "properties": {
+                    "pbtranscript.task_options.gmap_nproc": {
+                        "default": 24,
+                        "type": "integer",
+                        "description": "GMAP nproc",
+                        "title": "GMAP nproc"
+                    }
+                }
+            }
+        ],
+        "output_types": [
+            {
+                "title": "SAM file",
+                "description": "Gmap output sam",
+                "default_name": "gmap_output",
+                "id": "gmap_output_sam",
+                "file_type_id": "PacBio.FileTypes.sam"
+            }
+        ],
+        "_comment": "Created by v0.3.30",
+        "name": "pbtranscript.tasks.map_isoforms_to_genome",
+        "input_types": [
+            {
+                "description": "HQ isoforms FASTQ file",
+                "title": "FASTQ In",
+                "id": "hq_isoforms_fastq",
+                "file_type_id": "PacBio.FileTypes.Fastq"
+            },
+            {
+                "description": "Gmap reference set file",
+                "title": "GmapReferenceSet In",
+                "id": "gmap_referenceset",
+                "file_type_id": "PacBio.DataSet.GmapReferenceSet"
+            }
+        ],
+        "nproc": "$max_nproc",
+        "is_distributed": true,
+        "tool_contract_id": "pbtranscript.tasks.map_isoforms_to_genome"
+    }
+}

--- a/pbsmrtpipe/registered_tool_contracts_sa3/pbtranscript.tasks.post_mapping_to_genome_tool_contract.json
+++ b/pbsmrtpipe/registered_tool_contracts_sa3/pbtranscript.tasks.post_mapping_to_genome_tool_contract.json
@@ -1,0 +1,195 @@
+{
+    "version": "1.0.0.177900",
+    "driver": {
+        "serialization": "json",
+        "exe": "python -m pbtranscript.tasks.post_mapping_to_genome --resolved-tool-contract ",
+        "env": {}
+    },
+    "tool_contract_id": "pbtranscript.tasks.post_mapping_to_genome",
+    "tool_contract": {
+        "task_type": "pbsmrtpipe.task_types.standard",
+        "resource_types": [
+            "$tmpdir"
+        ],
+        "description": "Constants used in tool contract.",
+        "schema_options": [
+            {
+                "pb_option": {
+                    "default": 5,
+                    "type": "integer",
+                    "option_id": "pbtranscript.task_options.max_fuzzy_junction",
+                    "name": "max fuzzy junction",
+                    "description": "Max edit distance between merge-able fuzzy junctions (default: 5 bp)"
+                },
+                "title": "JSON Schema for pbtranscript.task_options.max_fuzzy_junction",
+                "required": [
+                    "pbtranscript.task_options.max_fuzzy_junction"
+                ],
+                "$schema": "http://json-schema.org/draft-04/schema#",
+                "type": "object",
+                "properties": {
+                    "pbtranscript.task_options.max_fuzzy_junction": {
+                        "default": 5,
+                        "type": "integer",
+                        "description": "Max edit distance between merge-able fuzzy junctions (default: 5 bp)",
+                        "title": "max fuzzy junction"
+                    }
+                }
+            },
+            {
+                "pb_option": {
+                    "default": 0.99,
+                    "type": "number",
+                    "option_id": "pbtranscript.task_options.min_gmap_aln_coverage",
+                    "name": "min gmap aln coverage",
+                    "description": "Min query coverage to analyze a GMAP alignment (default: 0.99)"
+                },
+                "title": "JSON Schema for pbtranscript.task_options.min_gmap_aln_coverage",
+                "required": [
+                    "pbtranscript.task_options.min_gmap_aln_coverage"
+                ],
+                "$schema": "http://json-schema.org/draft-04/schema#",
+                "type": "object",
+                "properties": {
+                    "pbtranscript.task_options.min_gmap_aln_coverage": {
+                        "default": 0.99,
+                        "type": "number",
+                        "description": "Min query coverage to analyze a GMAP alignment (default: 0.99)",
+                        "title": "min gmap aln coverage"
+                    }
+                }
+            },
+            {
+                "pb_option": {
+                    "default": 0.95,
+                    "type": "number",
+                    "option_id": "pbtranscript.task_options.min_gmap_aln_identity",
+                    "name": "min gmap aln identity",
+                    "description": "Min identity to analyze a GMAP alignment (default: 0.95)"
+                },
+                "title": "JSON Schema for pbtranscript.task_options.min_gmap_aln_identity",
+                "required": [
+                    "pbtranscript.task_options.min_gmap_aln_identity"
+                ],
+                "$schema": "http://json-schema.org/draft-04/schema#",
+                "type": "object",
+                "properties": {
+                    "pbtranscript.task_options.min_gmap_aln_identity": {
+                        "default": 0.95,
+                        "type": "number",
+                        "description": "Min identity to analyze a GMAP alignment (default: 0.95)",
+                        "title": "min gmap aln identity"
+                    }
+                }
+            },
+            {
+                "pb_option": {
+                    "default": false,
+                    "type": "boolean",
+                    "option_id": "pbtranscript.task_options.allow_extra_5exon",
+                    "name": "allow extra 5exon",
+                    "description": "True: Collapse shorter 5' transcripts. False: Don't collapse shorter 5' transcripts (default: False)"
+                },
+                "title": "JSON Schema for pbtranscript.task_options.allow_extra_5exon",
+                "required": [
+                    "pbtranscript.task_options.allow_extra_5exon"
+                ],
+                "$schema": "http://json-schema.org/draft-04/schema#",
+                "type": "object",
+                "properties": {
+                    "pbtranscript.task_options.allow_extra_5exon": {
+                        "default": false,
+                        "type": "boolean",
+                        "description": "True: Collapse shorter 5' transcripts. False: Don't collapse shorter 5' transcripts (default: False)",
+                        "title": "allow extra 5exon"
+                    }
+                }
+            },
+            {
+                "pb_option": {
+                    "default": 2,
+                    "type": "integer",
+                    "option_id": "pbtranscript.task_options.min_fl_count",
+                    "name": "min FL count",
+                    "description": "Minimum FL count to not filter a collapsed isoform"
+                },
+                "title": "JSON Schema for pbtranscript.task_options.min_fl_count",
+                "required": [
+                    "pbtranscript.task_options.min_fl_count"
+                ],
+                "$schema": "http://json-schema.org/draft-04/schema#",
+                "type": "object",
+                "properties": {
+                    "pbtranscript.task_options.min_fl_count": {
+                        "default": 2,
+                        "type": "integer",
+                        "description": "Minimum FL count to not filter a collapsed isoform",
+                        "title": "min FL count"
+                    }
+                }
+            }
+        ],
+        "output_types": [
+            {
+                "title": "FASTQ file",
+                "description": "Representative sequences of collapsed filtered isoforms",
+                "default_name": "output_mapped",
+                "id": "collapsed_filtered_isoforms_fq",
+                "file_type_id": "PacBio.FileTypes.Fastq"
+            },
+            {
+                "title": "GFF file",
+                "description": "Collapsed filtered isoforms gff",
+                "default_name": "output_mapped",
+                "id": "collapsed_filtered_isoforms_gff",
+                "file_type_id": "PacBio.FileTypes.gff"
+            },
+            {
+                "title": "TXT file",
+                "description": "Abundance file",
+                "default_name": "output_mapped_abundance",
+                "id": "abundance_txt",
+                "file_type_id": "PacBio.FileTypes.txt"
+            },
+            {
+                "title": "TXT file",
+                "description": "Collapsed isoform groups",
+                "default_name": "output_mapped_groups",
+                "id": "groups_txt",
+                "file_type_id": "PacBio.FileTypes.txt"
+            },
+            {
+                "title": "TXT file",
+                "description": "Read status of FL and nFL reads",
+                "default_name": "output_mapped_read_stat",
+                "id": "read_stat_txt",
+                "file_type_id": "PacBio.FileTypes.txt"
+            }
+        ],
+        "_comment": "Created by v0.3.30",
+        "name": "pbtranscript.tasks.post_mapping_to_genome",
+        "input_types": [
+            {
+                "description": "Input HQ polished isoforms in FASTQ file",
+                "title": "FASTQ In",
+                "id": "hq_isoforms_fq",
+                "file_type_id": "PacBio.FileTypes.Fastq"
+            },
+            {
+                "description": "Sorted GMAP SAM file",
+                "title": "SAM In",
+                "id": "sorted_gmap_sam",
+                "file_type_id": "PacBio.FileTypes.sam"
+            },
+            {
+                "description": "Pickle file containing dicts mapping HQ (LQ) sample prefixes to ICE cluster output directories",
+                "title": "PICKLE In",
+                "id": "hq_lq_pre_dict",
+                "file_type_id": "PacBio.FileTypes.pickle"
+            }
+        ],
+        "nproc": "$max_nproc",
+        "is_distributed": true,
+        "tool_contract_id": "pbtranscript.tasks.post_mapping_to_genome"
+    }
+}

--- a/pbsmrtpipe/registered_tool_contracts_sa3/pbtranscript.tasks.scatter_map_isoforms_to_genome_tool_contract.json
+++ b/pbsmrtpipe/registered_tool_contracts_sa3/pbtranscript.tasks.scatter_map_isoforms_to_genome_tool_contract.json
@@ -1,0 +1,72 @@
+{
+    "version": "0.1.0",
+    "driver": {
+        "serialization": "json",
+        "exe": "python -m pbtranscript.tasks.scatter_map_isoforms_to_genome --resolved-tool-contract ",
+        "env": {}
+    },
+    "tool_contract_id": "pbtranscript.tasks.scatter_map_isoforms_to_genome",
+    "tool_contract": {
+        "task_type": "pbsmrtpipe.task_types.scattered",
+        "resource_types": [],
+        "description": "\nScatter inputs of map_isoforms_to_genome.\n\nmap_isoforms_to_genome takes two inputs:\n    idx-0 HQ isoforms FASTQ\n    idx-1 GMAP reference dataset\nscatter_map_isoforms_to_genome chunks HQ isoforms and copies GMAP\nreference dataset to chunk.json.\n",
+        "schema_options": [
+            {
+                "pb_option": {
+                    "default": 24,
+                    "type": "integer",
+                    "option_id": "pbsmrtpipe.task_options.dev_scatter_max_nchunks",
+                    "name": "Max NChunks",
+                    "description": "Maximum number of Chunks"
+                },
+                "title": "JSON Schema for pbsmrtpipe.task_options.dev_scatter_max_nchunks",
+                "required": [
+                    "pbsmrtpipe.task_options.dev_scatter_max_nchunks"
+                ],
+                "$schema": "http://json-schema.org/draft-04/schema#",
+                "type": "object",
+                "properties": {
+                    "pbsmrtpipe.task_options.dev_scatter_max_nchunks": {
+                        "default": 24,
+                        "type": "integer",
+                        "description": "Maximum number of Chunks",
+                        "title": "Max NChunks"
+                    }
+                }
+            }
+        ],
+        "output_types": [
+            {
+                "title": "Chunk JSON Map Isoforms Tasks",
+                "description": "Chunked JSON Map Isoforms Tasks",
+                "default_name": "map_isoforms_to_genome.chunked",
+                "id": "cjson_out",
+                "file_type_id": "PacBio.FileTypes.CHUNK"
+            }
+        ],
+        "_comment": "Created by v0.3.30",
+        "nchunks": "$max_nchunks",
+        "name": "Scatter Map Isoforms Chunks",
+        "input_types": [
+            {
+                "description": "HQ isoforms FASTQ file",
+                "title": "FASTQ In",
+                "id": "fastq_in",
+                "file_type_id": "PacBio.FileTypes.Fastq"
+            },
+            {
+                "description": "Gmap reference set file",
+                "title": "GmapReferenceSet In",
+                "id": "gmap_referenceset",
+                "file_type_id": "PacBio.DataSet.GmapReferenceSet"
+            }
+        ],
+        "chunk_keys": [
+            "$chunk.fastq_id",
+            "$chunk.gmap_ref_id"
+        ],
+        "nproc": 1,
+        "is_distributed": true,
+        "tool_contract_id": "pbtranscript.tasks.scatter_map_isoforms_to_genome"
+    }
+}

--- a/pbsmrtpipe/registered_tool_contracts_sa3/pbtranscript.tasks.separate_flnc_tool_contract.json
+++ b/pbsmrtpipe/registered_tool_contracts_sa3/pbtranscript.tasks.separate_flnc_tool_contract.json
@@ -1,109 +1,109 @@
 {
-    "version": "1.0.0.177015", 
+    "version": "1.0.0.177900",
     "driver": {
-        "serialization": "json", 
-        "exe": "python -m pbtranscript.tasks.separate_flnc --resolved-tool-contract", 
+        "serialization": "json",
+        "exe": "python -m pbtranscript.tasks.separate_flnc --resolved-tool-contract",
         "env": {}
-    }, 
-    "tool_contract_id": "pbtranscript.tasks.separate_flnc", 
+    },
+    "tool_contract_id": "pbtranscript.tasks.separate_flnc",
     "tool_contract": {
-        "task_type": "pbsmrtpipe.task_types.standard", 
+        "task_type": "pbsmrtpipe.task_types.standard",
         "resource_types": [
             "$tmpdir"
-        ], 
-        "description": "Constants used in tool contract.", 
+        ],
+        "description": "Constants used in tool contract.",
         "schema_options": [
             {
                 "pb_option": {
-                    "default": 1, 
-                    "type": "integer", 
-                    "option_id": "pbtranscript.task_options.bin_size_kb", 
-                    "name": "Bin by read length in KB", 
+                    "default": 1,
+                    "type": "integer",
+                    "option_id": "pbtranscript.task_options.bin_size_kb",
+                    "name": "Bin by read length in KB",
                     "description": "Bin size by kb (default: 1)"
-                }, 
-                "title": "JSON Schema for pbtranscript.task_options.bin_size_kb", 
+                },
+                "title": "JSON Schema for pbtranscript.task_options.bin_size_kb",
                 "required": [
                     "pbtranscript.task_options.bin_size_kb"
-                ], 
-                "$schema": "http://json-schema.org/draft-04/schema#", 
-                "type": "object", 
+                ],
+                "$schema": "http://json-schema.org/draft-04/schema#",
+                "type": "object",
                 "properties": {
                     "pbtranscript.task_options.bin_size_kb": {
-                        "default": 1, 
-                        "type": "integer", 
-                        "description": "Bin size by kb (default: 1)", 
+                        "default": 1,
+                        "type": "integer",
+                        "description": "Bin size by kb (default: 1)",
                         "title": "Bin by read length in KB"
                     }
                 }
-            }, 
+            },
             {
                 "pb_option": {
-                    "default": "[]", 
-                    "type": "string", 
-                    "option_id": "pbtranscript.task_options.bin_manual", 
-                    "name": "Bin by read length manually", 
-                    "description": "Bin manual (ex: (1,2,3,5)), overwrites bin_size_kb"
-                }, 
-                "title": "JSON Schema for pbtranscript.task_options.bin_manual", 
+                    "default": "[]",
+                    "type": "string",
+                    "option_id": "pbtranscript.task_options.bin_manual",
+                    "name": "Bin by read length manually",
+                    "description": "Bin manual (ex: (1,2,3,5)), overwrites bin_size_kb (default: [])"
+                },
+                "title": "JSON Schema for pbtranscript.task_options.bin_manual",
                 "required": [
                     "pbtranscript.task_options.bin_manual"
-                ], 
-                "$schema": "http://json-schema.org/draft-04/schema#", 
-                "type": "object", 
+                ],
+                "$schema": "http://json-schema.org/draft-04/schema#",
+                "type": "object",
                 "properties": {
                     "pbtranscript.task_options.bin_manual": {
-                        "default": "[]", 
-                        "type": "string", 
-                        "description": "Bin manual (ex: (1,2,3,5)), overwrites bin_size_kb", 
+                        "default": "[]",
+                        "type": "string",
+                        "description": "Bin manual (ex: (1,2,3,5)), overwrites bin_size_kb (default: [])",
                         "title": "Bin by read length manually"
                     }
                 }
-            }, 
+            },
             {
                 "pb_option": {
-                    "default": false, 
-                    "type": "boolean", 
-                    "option_id": "pbtranscript.task_options.bin_by_primer", 
-                    "name": "Bin by primer", 
-                    "description": "Instead of binning by size, bin by primer (overwrites --bin_size_kb and --bin_manual)"
-                }, 
-                "title": "JSON Schema for pbtranscript.task_options.bin_by_primer", 
+                    "default": false,
+                    "type": "boolean",
+                    "option_id": "pbtranscript.task_options.bin_by_primer",
+                    "name": "Bin by primer",
+                    "description": "Instead of binning by size, bin by primer (overwrites --bin_size_kb and --bin_manual) (default: False)"
+                },
+                "title": "JSON Schema for pbtranscript.task_options.bin_by_primer",
                 "required": [
                     "pbtranscript.task_options.bin_by_primer"
-                ], 
-                "$schema": "http://json-schema.org/draft-04/schema#", 
-                "type": "object", 
+                ],
+                "$schema": "http://json-schema.org/draft-04/schema#",
+                "type": "object",
                 "properties": {
                     "pbtranscript.task_options.bin_by_primer": {
-                        "default": false, 
-                        "type": "boolean", 
-                        "description": "Instead of binning by size, bin by primer (overwrites --bin_size_kb and --bin_manual)", 
+                        "default": false,
+                        "type": "boolean",
+                        "description": "Instead of binning by size, bin by primer (overwrites --bin_size_kb and --bin_manual) (default: False)",
                         "title": "Bin by primer"
                     }
                 }
             }
-        ], 
+        ],
         "output_types": [
             {
-                "title": "Pickle file", 
-                "description": "Python pickle file of how flnc reads are separated", 
-                "default_name": "separate_flnc", 
-                "id": "out_pickle", 
+                "title": "Pickle file",
+                "description": "output bins in pickle.",
+                "default_name": "separate_flnc",
+                "id": "out_pickle",
                 "file_type_id": "PacBio.FileTypes.pickle"
             }
-        ], 
-        "_comment": "Created by v0.3.25", 
-        "name": "pbtranscript.tasks.separate_flnc", 
+        ],
+        "_comment": "Created by v0.3.30",
+        "name": "pbtranscript.tasks.separate_flnc",
         "input_types": [
             {
-                "description": "Input full-length non-chimeric reads in FASTA or ContigSet format, used for clustering consensus isoforms, e.g., isoseq_flnc.fasta", 
-                "title": "FASTA or ContigSet file", 
-                "id": "flnc_fa", 
+                "description": "FLNC reads ContigSet",
+                "title": "FASTA or ContigSet file",
+                "id": "flnc_fa",
                 "file_type_id": "PacBio.DataSet.ContigSet"
             }
-        ], 
-        "nproc": "$max_nproc", 
-        "is_distributed": true, 
+        ],
+        "nproc": "$max_nproc",
+        "is_distributed": true,
         "tool_contract_id": "pbtranscript.tasks.separate_flnc"
     }
 }


### PR DESCRIPTION
sa3_ds_isoseq_with_genome starts from subreads and requires a
reference genome GMAP dataset.

This pipeline (1) calls the sa3_ds_isoseq pipeline, (2)
maps isoforms to the reference genome using GMAP, (3) collapses
redundant isoforms based on mapping, (4) counts abundance
of collapsed isoforms and (5) filters collapsed isoforms by count.