### PR TITLE
Expose customer primers in isoseq

### DIFF
--- a/pbsmrtpipe/pb_pipelines/pb_pipelines_sa3.py
+++ b/pbsmrtpipe/pb_pipelines/pb_pipelines_sa3.py
@@ -654,6 +654,18 @@ def ds_isoseq_with_genome():
     return b1 + b2 + b3
 
 
+@sa3_register("pb_isoseq_classify", "Internal Iso-Seq Classify Only for tests", "0.2.0",
+              tags=(Tags.MAP, Tags.CCS, Tags.ISOSEQ),
+              task_options=ISOSEQ_TASK_OPTIONS)
+def pb_isoseq_classify():
+    """
+    Partial Iso-Seq pipeline (classify step only), starting from ccs.
+    This pipeline was added to test isoseq-classify with customer primers on
+    the only data that we currently have (which could not ccs-ed by ccs2).
+    """
+    return _core_isoseq_classify(ccs_ds=Constants.ENTRY_DS_CCS)
+
+
 @sa3_register("pb_isoseq", "Internal Iso-Seq pipeline", "0.2.0", tags=(Tags.MAP, Tags.CCS, Tags.ISOSEQ, Tags.INTERNAL))
 def pb_isoseq():
     """

--- a/pbsmrtpipe/registered_tool_contracts_sa3/pbtranscript.tasks.classify_tool_contract.json
+++ b/pbsmrtpipe/registered_tool_contracts_sa3/pbtranscript.tasks.classify_tool_contract.json
@@ -15,6 +15,29 @@
         "schema_options": [
             {
                 "pb_option": {
+                    "default": "",
+                    "type": "string",
+                    "option_id": "pbtranscript.task_options.primer_sequences",
+                    "name": "Customer primer sequences",
+                    "description": "Customer primer sequences."
+                },
+                "title": "JSON Schema for pbtranscript.task_options.primer_sequences",
+                "required": [
+                    "pbtranscript.task_options.primer_sequences"
+                ],
+                "$schema": "http://json-schema.org/draft-04/schema#",
+                "type": "object",
+                "properties": {
+                    "pbtranscript.task_options.primer_sequences": {
+                        "default": "",
+                        "type": "string",
+                        "description": "Customer primer sequences.",
+                        "title": "Customer primer sequences"
+                    }
+                }
+            },
+            {
+                "pb_option": {
                     "default": 50,
                     "type": "integer",
                     "option_id": "pbtranscript.task_options.min_seq_len",
@@ -97,7 +120,7 @@
                 "file_type_id": "PacBio.FileTypes.csv"
             }
         ],
-        "_comment": "Created by v0.4.3",
+        "_comment": "Created by v0.3.30",
         "name": "pbtranscript.tasks.classify",
         "input_types": [
             {


### PR DESCRIPTION
* Updated pbtranscript.tasks.classify tool contract.
* Added an internal pipeline pb_isoseq_classify which
  starts from CCS for test purpose.