### PR TITLE
update mapping stat reports file names in TC

### DIFF
--- a/pbsmrtpipe/registered_tool_contracts_sa3/pbreports.tasks.mapping_stats_ccs_tool_contract.json
+++ b/pbsmrtpipe/registered_tool_contracts_sa3/pbreports.tasks.mapping_stats_ccs_tool_contract.json
@@ -13,7 +13,7 @@
         "schema_options": [], 
         "output_types": [
             {
-                "title": "PacBio Json Report", 
+                "title": "CCS Mapping Statistics Report", 
                 "description": "Output report JSON file.", 
                 "default_name": "mapping_stats_report", 
                 "id": "report_json", 

--- a/pbsmrtpipe/registered_tool_contracts_sa3/pbreports.tasks.mapping_stats_tool_contract.json
+++ b/pbsmrtpipe/registered_tool_contracts_sa3/pbreports.tasks.mapping_stats_tool_contract.json
@@ -13,7 +13,7 @@
         "schema_options": [], 
         "output_types": [
             {
-                "title": "PacBio Json Report", 
+                "title": "Mapping Statistics Report", 
                 "description": "Output report JSON file.", 
                 "default_name": "mapping_stats_report", 
                 "id": "report_json", 


### PR DESCRIPTION
found another file name bug. these fall under bug 33026 'clean up and rationalize output file labels in GUI' so i didn't create a separate ticket here. 