### PR TITLE
change datastore sourceId format and behavior

### DIFF
--- a/pbsmrtpipe/__init__.py
+++ b/pbsmrtpipe/__init__.py
@@ -1,4 +1,4 @@
-VERSION = (0, 43, 0)
+VERSION = (0, 43, 1)
 
 
 def get_version():

--- a/pbsmrtpipe/driver.py
+++ b/pbsmrtpipe/driver.py
@@ -336,8 +336,13 @@ def __exe_workflow(global_registry, ep_d, bg, task_opts, workflow_opts, output_d
         assert (len(tnode_.meta_task.output_file_display_names) ==
                 len(tnode_.meta_task.output_file_descriptions) ==
                 len(tnode_.meta_task.output_types) == len(task_.output_files))
-        for file_type_, path_, name, description in zip(tnode_.meta_task.output_types, task_.output_files, tnode_.meta_task.output_file_display_names, tnode_.meta_task.output_file_descriptions):
-            source_id = "{t}-{f}".format(t=task_.task_id, f=file_type_.file_type_id)
+        for i_file, (file_type_, path_, name, description) in enumerate(zip(
+                tnode_.meta_task.output_types, task_.output_files,
+                tnode_.meta_task.output_file_display_names,
+                tnode_.meta_task.output_file_descriptions)):
+            source_id = "{t}-out-{i}".format(t=task_.task_id, i=i_file)
+            if tnode_.meta_task.datastore_source_id is not None:
+                source_id = tnode_.meta_task.datastore_source_id
             ds_uuid = _get_or_create_uuid_from_file(path_, file_type_)
             is_chunked_ = _is_chunked_task_node_type(tnode_)
             ds_file_ = DataStoreFile(ds_uuid, source_id, file_type_.file_type_id, path_, is_chunked=is_chunked_, name=name, description=description)

--- a/pbsmrtpipe/graph/bgraph.py
+++ b/pbsmrtpipe/graph/bgraph.py
@@ -1404,8 +1404,13 @@ def add_gather_to_completed_task_chunks(bg, chunk_operators_d, registered_tasks_
 
                         g_meta_task = copy.deepcopy(registered_tasks_d[gchunk.gather_task_id])
                         g_node = bg.add_gather_meta_task(g_meta_task, gchunk.chunk_key)
+                        # the name, description, and sourceId fields in the
+                        # datastore should be populated from the original task,
+                        # not the gather task
                         g_meta_task.output_file_display_names[0] = original_task.output_file_display_names[gi]
                         g_meta_task.output_file_descriptions[0] = original_task.output_file_descriptions[gi]
+                        g_meta_task.datastore_source_id = "{t}-out-{i}".format(
+                            t=original_task.task_id, i=gi)
 
                         # Both In/Out Gather Binding Types only have one input and
                         # one output, hence, the positional in/out index is ALWAYS 0

--- a/pbsmrtpipe/models.py
+++ b/pbsmrtpipe/models.py
@@ -231,6 +231,7 @@ class MetaTask(object):
             output_file_display_names is not None else ["" for x in output_file_names]
         self.output_file_descriptions = output_file_descriptions if \
             output_file_descriptions is not None else ["" for x in output_file_names]
+        self.datastore_source_id = None
 
     def __eq__(self, other):
         # need to rethink this.

--- a/pbsmrtpipe/testkit/core/test_datastore.py
+++ b/pbsmrtpipe/testkit/core/test_datastore.py
@@ -61,6 +61,9 @@ class TestDataStoreFileLabels(TestBase):
 
 
 class TestDataStoreUuids(TestBase):
+    """
+    Verify that report and DataSet UUIDs are propagated to the datastore.
+    """
 
     def test_datastore_report_file_uuid(self):
         p = os.path.join(self.job_dir, "workflow", "datastore.json")

--- a/pbsmrtpipe/testkit/core/test_datastore_chunking.py
+++ b/pbsmrtpipe/testkit/core/test_datastore_chunking.py
@@ -1,0 +1,57 @@
+
+"""
+Specialized tests for datastore behavior when chunking is used, including
+propagation of sourceId, name, and description fields from the original task.
+Note that this test is *not* suitable for pipelines like dev_diagnostic_stress
+which run a specific task more than once.
+"""
+
+import unittest
+import os
+import logging
+import json
+import re
+
+from pbcommand.pb_io.report import load_report_from_json
+from pbcommand.models import FileTypes
+from pbcore.io import getDataSetUuid
+
+from .base import TestBase
+
+
+class TestDataStoreSourceIds(TestBase):
+
+    def test_datastore_unchunked_source_ids_unique(self):
+        p = os.path.join(self.job_dir, "workflow", "datastore.json")
+        with open(p, 'r') as r:
+            d = json.loads(r.read())
+            source_ids = set()
+            for file_info in d['files']:
+                if file_info['isChunked']:
+                    continue
+                self.assertFalse(file_info['sourceId'] in source_ids,
+                                 "{i} occurs more than once".format(
+                                 i=file_info['sourceId']))
+                source_ids.add(file_info['sourceId'])
+
+    def test_datastore_chunk_gather_consistency(self):
+        p = os.path.join(self.job_dir, "workflow", "datastore.json")
+        with open(p, 'r') as r:
+            d = json.loads(r.read())
+            chunked_files = {}
+            unchunked_files = {}
+            for file_info in d['files']:
+                if not file_info['isChunked']:
+                    unchunked_files[file_info['sourceId']] = file_info
+            for file_info in d['files']:
+                if file_info['isChunked']:
+                    # CHUNK JSON files from scatter tasks are a special case
+                    if file_info['fileTypeId'] == "PacBio.FileTypes.CHUNK":
+                        continue
+                    gathered = unchunked_files.get(file_info['sourceId'], None)
+                    self.assertTrue(gathered is not None,
+                                    "Can't find gathered file {i}".format(
+                                    i=file_info['sourceId']))
+                    self.assertEqual(file_info['name'], gathered['name'])
+                    self.assertEqual(file_info['description'],
+                                     gathered['description'])

--- a/testkit-data/dev_diagnostic/testkit.cfg
+++ b/testkit-data/dev_diagnostic/testkit.cfg
@@ -17,4 +17,4 @@ eid_ref_dataset = referenceset.xml
 [tests]
 # Tests can be loaded from any python module
 # specifically, Any TestBase subclass in pbsmrtpipe.teskit.core.test_zero will be loaded
-pbsmrtpipe.testkit.core = test_zero, test_resources, test_datastore
+pbsmrtpipe.testkit.core = test_zero, test_resources, test_datastore, test_datastore_chunking

--- a/testkit-data/dev_local_chunk/testkit.cfg
+++ b/testkit-data/dev_local_chunk/testkit.cfg
@@ -16,4 +16,4 @@ e_01 = input.txt
 [tests]
 # Tests can be loaded from any python module
 # specifically, Any TestBase subclass in pbsmrtpipe.teskit.core.test_zero will be loaded
-pbsmrtpipe.testkit.core = test_zero, test_resources, test_datastore
+pbsmrtpipe.testkit.core = test_zero, test_resources, test_datastore, test_datastore_chunking

--- a/testkit-data/dev_local_fasta_chunk/testkit.cfg
+++ b/testkit-data/dev_local_fasta_chunk/testkit.cfg
@@ -17,4 +17,4 @@ e_01 = input.txt
 [tests]
 # Tests can be loaded from any python module
 # specifically, Any TestBase subclass in pbsmrtpipe.teskit.core.test_zero will be loaded
-pbsmrtpipe.testkit.core = test_zero, test_resources, test_datastore
+pbsmrtpipe.testkit.core = test_zero, test_resources, test_datastore, test_datastore_chunking


### PR DESCRIPTION
Gather task outputs now inherit sourceId from the underlying chunked tasks