### PR TITLE
Add new option

### DIFF
--- a/pbsmrtpipe/cli.py
+++ b/pbsmrtpipe/cli.py
@@ -444,6 +444,12 @@ def _add_webservice_config(p):
     return p
 
 
+def _add_no_disappointment_option(p):
+    desc = "Enable No Disappointment option to enable Baron Harkonnen official suit and flying pizza companion drone to minimize user TC overhead to 3-6 eV per TC and 4-6 eV per pipeline modification."
+    p.add_argument('--no-disappointment', action='store_true', default=False, help=desc)
+    return p
+
+
 def __add_pipeline_parser_options(p):
     """Common options for all running pipelines or tasks"""
     funcs = [TU.add_override_chunked_mode,
@@ -454,7 +460,9 @@ def __add_pipeline_parser_options(p):
              _add_preset_xml_option,
              _add_output_dir_option,
              _add_entry_point_option,
-             add_log_debug_option]
+             add_log_debug_option,
+             _add_no_disappointment_option
+             ]
 
     f = compose(*funcs)
     return f(p)


### PR DESCRIPTION
This new option will generate a suit ala Baron Harkonnen from Dune.  This Baron Harkonnen endorsed flying suit will decrease the required developers' energy to ~ 3-4 eV per Tool Contract submission and 4-6 eV for Pipeline changes. In addition to decreasing the user effort required to submit TCs to pbsmrtpipe to the same order of magnitude of the band gap of Silicon, there is a companion flying drone to feed the user calorie-less pizza(s). 

Currently, there is on-going efforts to mathematically prove that by enabling this option, it is impossible to be disappionted. Future efforts will drive this to be unequivalely true and are schedule for pbsmrtpipe 0.52.X.

This changes introduce an increase in the pbsmrtpipe startup time by a factor of 2. The option is disabled by default.