### PR TITLE
Better warning message for unknown supplied Task Options

### DIFF
--- a/pbsmrtpipe/driver.py
+++ b/pbsmrtpipe/driver.py
@@ -772,7 +772,7 @@ def _load_io_for_workflow(registered_tasks, registered_pipelines, workflow_templ
 
     slog.info("validating supplied task options.")
     topts = IO.validate_raw_task_options(registered_tasks, topts)
-    slog.info("successfully validated (pre DI) task options.")
+    slog.info("successfully loaded and validated task options.")
 
     workflow_bindings = builder_record.bindings
 

--- a/pbsmrtpipe/pb_io.py
+++ b/pbsmrtpipe/pb_io.py
@@ -394,7 +394,7 @@ def validate_raw_task_option(registered_tasks, option_id, raw_value):
     if option_id in opts:
         value = _raw_option_with_schema(option_id, raw_value, opts[option_id])
     else:
-        log.warn("Unknown option '{i}'. Ignoring".format(i=option_id))
+        log.warn("UNKNOWN TASK OPTION with id '{i}'. Ignoring option".format(i=option_id))
         value = None
 
     return value

--- a/pbsmrtpipe/pb_io.py
+++ b/pbsmrtpipe/pb_io.py
@@ -394,7 +394,7 @@ def validate_raw_task_option(registered_tasks, option_id, raw_value):
     if option_id in opts:
         value = _raw_option_with_schema(option_id, raw_value, opts[option_id])
     else:
-        log.warn("UNKNOWN TASK OPTION with id '{i}'. Ignoring option".format(i=option_id))
+        log.warn("UNKNOWN Task Option with id '{i}'. Ignoring option".format(i=option_id))
         value = None
 
     return value
@@ -423,7 +423,7 @@ def validate_workflow_options(d):
     """
     for option_id in d:
         if option_id not in REGISTERED_WORKFLOW_OPTIONS:
-            msg = "Unknown option. Ignoring workflow option '{i}'.".format(i=option_id)
+            msg = "UNKNOWN Workflow Level Option with id '{i}'. Ignoring option".format(i=option_id)
             log.warn(msg)
 
     wopts = []

--- a/testkit-data/dev_01/preset.xml
+++ b/testkit-data/dev_01/preset.xml
@@ -27,6 +27,11 @@
             <value>pbsmrtpipe.cluster_templates.sge</value>
         </option>
 
+	<!-- Testing for options that are not part of the schema -->
+        <option id="pbsmrtpipe.options.not_a_option" >
+            <value>11234</value>
+        </option>
+
     </options>
 
     <!-- Default Task specific Options -->


### PR DESCRIPTION
The updated output to stdout (or job.stdout when run from testkit)

```
Loading workflow template.
Loading pipeline template id pbsmrtpipe.pipelines.dev_local
successfully loaded workflow template.
No JSON preset provided. Skipping preset json loading.
Loading preset(s) ['/Users/mkocher/gh_projects/pbsmrtpipe/testkit-data/dev_01/preset.xml']
UNKNOWN Workflow Level Option with id 'pbsmrtpipe.options.not_a_option'. Ignoring option
successfully loaded preset.
Successfully loaded cluster manager from pbsmrtpipe.cluster_templates.sge
Successfully validated workflow options.
validating supplied task options.
UNKNOWN Task Option with id 'pbsmrtpipe.task_option.option_id1'. Ignoring option
UNKNOWN Task Option with id 'pbsmrtpipe.task_option.option_id2'. Ignoring option
successfully loaded and validated task options.
overriding debug-mode to True
Resolved workflow level options to <WorkflowLevelOptions chunk:24 nproc:24 workers:100 cluster:pbsmrtpipe.cluster_templates.sge>
```

Currently, for both, workflow and task level options that are unknown option ids, there is a message printed to stdout on startup. I've updated the message use the same format (as shown above).


@bnbowman has suggested that raising an exception instead of emitting a message to stdout would be a better model. This would be a backward incompatible and would cause some breakage. 

@natechols I would suggest that when we remove support for XML in preset/workflow, we make that breaking change as well. 

