### PR TITLE
Don't override CCS default Z Score in pbsmrtpipe

### DIFF
--- a/pbsmrtpipe/pb_pipelines/pb_pipelines_sa3.py
+++ b/pbsmrtpipe/pb_pipelines/pb_pipelines_sa3.py
@@ -438,7 +438,6 @@ def ds_barcode_laa():
 # global defaults for CCS jobs
 CCS_TASK_OPTIONS = {
   "pbccs.task_options.min_read_score": 0.65,
-  "pbccs.task_options.min_zscore": -5.0,
 }
 
 def _core_ccs(subread_ds):


### PR DESCRIPTION
The override here was useful in the past when we had very aberrant
data (earlier Sequel), but since that time zscore was turned into an
RS-only feature.  We expect to turn it back on for Sequel soon.