### PR TITLE
Delete different las files at different stages

### DIFF
--- a/pbsmrtpipe/pb_pipelines/pb_pipeline_view_rules.py
+++ b/pbsmrtpipe/pb_pipelines/pb_pipeline_view_rules.py
@@ -179,6 +179,8 @@ def hgap4_view_rules():
         ("falcon_ns.tasks.task_falcon0_cons-out-0", FileTypes.TXT, True),
         ("falcon_ns.tasks.task_falcon1_merge-out-0", FileTypes.TXT, True),
         ("falcon_ns.tasks.task_falcon1_db2falcon-out-0", FileTypes.TXT, True),
+        ("falcon_ns.tasks.task_falcon0_rm_las-out-0", FileTypes.TXT, True),
+        ("falcon_ns.tasks.task_falcon1_rm_las-out-0", FileTypes.TXT, True),
         ("falcon_ns.tasks.task_falcon2_rm_las-out-0", FileTypes.TXT, True),
         ("pbcoretools.tasks.fasta2referenceset-out-0", FileTypes.DS_REF, False, "Draft Assembly")
     ] + _mapping_report_rules()

--- a/pbsmrtpipe/pb_pipelines/pb_pipelines_falcon.py
+++ b/pbsmrtpipe/pb_pipelines/pb_pipelines_falcon.py
@@ -29,6 +29,8 @@ def _get_falcon_pipeline(i_cfg, i_fasta_fofn):
           ('falcon_ns.tasks.task_falcon_config:0',     'falcon_ns.tasks.task_falcon0_run_daligner_jobs:0'),
           ('falcon_ns.tasks.task_falcon0_build_rdb:0', 'falcon_ns.tasks.task_falcon0_run_daligner_jobs:1'),
          ]
+    rm0 = [('falcon_ns.tasks.task_falcon0_run_daligner_jobs:0', 'falcon_ns.tasks.task_falcon0_rm_las:0')] # rm raw_reads.*.raw_reads.*.las
+
     # br2: make scripts, LAmerge (e.g., m_00001/merge_00001.sh), LA4Falcon (e.g., preads/c_00001.sh) and db2falcon scripts.
     br2 = [
           ('falcon_ns.tasks.task_falcon_config:0',             'falcon_ns.tasks.task_falcon0_run_merge_consensus_jobs:0'),
@@ -41,11 +43,14 @@ def _get_falcon_pipeline(i_cfg, i_fasta_fofn):
     br4 = [('falcon_ns.tasks.task_falcon0_run_merge_consensus_jobs:2', 'falcon_ns.tasks.task_falcon0_cons:0'),      # cons.json
            ('falcon_ns.tasks.task_falcon0_merge:0',                    'falcon_ns.tasks.task_falcon0_cons:1')       # merge_done.txt, sentinel
           ]
+    rm1 = [('falcon_ns.tasks.task_falcon0_cons:0', 'falcon_ns.tasks.task_falcon1_rm_las:0')] # rm raw_reads.*.las
+
     bp0 = [
           ('falcon_ns.tasks.task_falcon_config:0',                    'falcon_ns.tasks.task_falcon1_build_pdb:0'),  # config.json
           ('falcon_ns.tasks.task_falcon0_run_merge_consensus_jobs:0', 'falcon_ns.tasks.task_falcon1_build_pdb:1'),  # fofn of out.*.fasta
           ('falcon_ns.tasks.task_falcon0_cons:0',                     'falcon_ns.tasks.task_falcon1_build_pdb:2')   # cons_done.txt, sentinel
          ]
+
     bp1 = [
           ('falcon_ns.tasks.task_falcon_config:0',     'falcon_ns.tasks.task_falcon1_run_daligner_jobs:0'),
           ('falcon_ns.tasks.task_falcon1_build_pdb:0', 'falcon_ns.tasks.task_falcon1_run_daligner_jobs:1'),
@@ -66,7 +71,7 @@ def _get_falcon_pipeline(i_cfg, i_fasta_fofn):
             ('falcon_ns.tasks.task_falcon1_run_merge_consensus_jobs:0', 'falcon_ns.tasks.task_falcon2_run_asm:1'),  # fofn of preads.*.las
             ('falcon_ns.tasks.task_falcon1_db2falcon:0',                'falcon_ns.tasks.task_falcon2_run_asm:2')   # db2falcon_done.txt, sentinel
          ]
-    rm = [('falcon_ns.tasks.task_falcon2_run_asm:0', 'falcon_ns.tasks.task_falcon2_rm_las:0')] # sentinel fasta to trigger clean up
+    rm2 = [('falcon_ns.tasks.task_falcon2_run_asm:0', 'falcon_ns.tasks.task_falcon2_rm_las:0')] # clean up preads.*.las
 
     report_pay = [
           ('falcon_ns.tasks.task_falcon_config:0',
@@ -80,7 +85,7 @@ def _get_falcon_pipeline(i_cfg, i_fasta_fofn):
     ]
     results = dict()
     results['asm'] = 'falcon_ns.tasks.task_falcon2_run_asm:0'
-    return b0 + br0 + br1 + br2 + br3 + br4 + bp0 + bp1 + bp2 + bp3 + bp4 + bf + rm + report_pay, results
+    return b0 + br0 + br1 + rm0 + br2 + br3 + br4 + rm1 + bp0 + bp1 + bp2 + bp3 + bp4 + bf + rm2 + report_pay, results
 
 def _get_polished_falcon_pipeline():
     subreadset = Constants.ENTRY_DS_SUBREAD

--- a/pbsmrtpipe/registered_tool_contracts_sa3/falcon_ns.tasks.task_falcon0_rm_las_tool_contract.json
+++ b/pbsmrtpipe/registered_tool_contracts_sa3/falcon_ns.tasks.task_falcon0_rm_las_tool_contract.json
@@ -1,0 +1,37 @@
+{
+    "driver": {
+        "env": {},
+        "exe": "python -m pbfalcon.tasks.basic  run-rtc  ",
+        "serialization": "json"
+    },
+    "tool_contract": {
+        "_comment": "Created by v0.4.14",
+        "description": "Quick tool task_falcon0_rm_las falcon_ns.tasks.task_falcon0_rm_las",
+        "input_types": [
+            {
+                "description": "description for PacBio.FileTypes.generic_fofn_0",
+                "file_type_id": "PacBio.FileTypes.generic_fofn",
+                "id": "Label PacBio.FileTypes.generic_fofn_0",
+                "title": "<OutputFileType PacBio.FileTypes.generic_fofn fofn_id >"
+            }
+        ],
+        "is_distributed": true,
+        "name": "Tool task_falcon0_rm_las",
+        "nproc": 1,
+        "output_types": [
+            {
+                "default_name": "file",
+                "description": "description for <FileType id=PacBio.FileTypes.txt name=file >",
+                "file_type_id": "PacBio.FileTypes.txt",
+                "id": "Label PacBio.FileTypes.txt_0",
+                "title": "<FileType id=PacBio.FileTypes.txt name=file >"
+            }
+        ],
+        "resource_types": [],
+        "schema_options": [],
+        "task_type": "pbsmrtpipe.task_types.standard",
+        "tool_contract_id": "falcon_ns.tasks.task_falcon0_rm_las"
+    },
+    "tool_contract_id": "falcon_ns.tasks.task_falcon0_rm_las",
+    "version": "0.0.0"
+}

--- a/pbsmrtpipe/registered_tool_contracts_sa3/falcon_ns.tasks.task_falcon1_rm_las_tool_contract.json
+++ b/pbsmrtpipe/registered_tool_contracts_sa3/falcon_ns.tasks.task_falcon1_rm_las_tool_contract.json
@@ -1,0 +1,37 @@
+{
+    "driver": {
+        "env": {},
+        "exe": "python -m pbfalcon.tasks.basic  run-rtc  ",
+        "serialization": "json"
+    },
+    "tool_contract": {
+        "_comment": "Created by v0.4.14",
+        "description": "Quick tool task_falcon1_rm_las falcon_ns.tasks.task_falcon1_rm_las",
+        "input_types": [
+            {
+                "description": "description for PacBio.FileTypes.txt_0",
+                "file_type_id": "PacBio.FileTypes.txt",
+                "id": "Label PacBio.FileTypes.txt_0",
+                "title": "<OutputFileType PacBio.FileTypes.txt txt_id >"
+            }
+        ],
+        "is_distributed": true,
+        "name": "Tool task_falcon1_rm_las",
+        "nproc": 1,
+        "output_types": [
+            {
+                "default_name": "file",
+                "description": "description for <FileType id=PacBio.FileTypes.txt name=file >",
+                "file_type_id": "PacBio.FileTypes.txt",
+                "id": "Label PacBio.FileTypes.txt_0",
+                "title": "<FileType id=PacBio.FileTypes.txt name=file >"
+            }
+        ],
+        "resource_types": [],
+        "schema_options": [],
+        "task_type": "pbsmrtpipe.task_types.standard",
+        "tool_contract_id": "falcon_ns.tasks.task_falcon1_rm_las"
+    },
+    "tool_contract_id": "falcon_ns.tasks.task_falcon1_rm_las",
+    "version": "0.0.0"
+}


### PR DESCRIPTION
SAT-567, SAT-559

(1) delete raw_reads.\*.raw_reads.\*.las when falcon_ns.tasks.task_falcon0_run_daligner_jobs (gather0_run_daligner_jobs) is done
(2) delete raw_reads.\*.las when falcon_ns.tasks.task_falcon0_cons is done
(3) delete preads.\*.las when falcon_ns.tasks.task_falcon2_run_asm is done (we can even delete preads.\*.preads.\*.las earlier when falcon_ns.tasks.task_falcon1_merge is done)