### PR TITLE
Remove ignoreHQRegions option

### DIFF
--- a/pbsmrtpipe/pb_pipelines/pb_pipelines_sa3.py
+++ b/pbsmrtpipe/pb_pipelines/pb_pipelines_sa3.py
@@ -188,7 +188,7 @@ UNROLLED_TASK_OPTIONS = {
     "pbalign.task_options.no_split_subreads": True,
     "pbalign.task_options.hit_policy": "leftmost",
     "pbalign.task_options.concordant": False,
-    "pbalign.task_options.algorithm_options": "--bestn 1 --forwardOnly --fastMaxInterval --maxAnchorsPerPosition 30000 --ignoreHQRegions --minPctIdentity 60"
+    "pbalign.task_options.algorithm_options": "--bestn 1 --forwardOnly --fastMaxInterval --maxAnchorsPerPosition 30000 --minPctIdentity 60"
 }
 
 # XXX this is identical to sa3_ds_align but with modified task options


### PR DESCRIPTION
According to Yuan Li:

Whether or not ignoreHQRegion is turned on or off has *NO* impact on
output when input is bam or dataset.

So I don’t think it makes any sense to specify an option that has no
impact.

For review by: @mdsmith 